### PR TITLE
Add step to record new skills in example-skills-catalog

### DIFF
--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -378,3 +378,24 @@ ls -la ~/.claude/commands/<slug>-dev-loop.md
 
 Report the skill name (`/<slug>-dev-loop`) and a one-paragraph summary of the key
 repo-specific choices made (build system, test command, doc sources, reviewer, branch prefix).
+
+---
+
+### 6 — Record the skill in my-claude-skills
+
+Open `~/my-claude-skills/README.md` and append a new row to the skills table:
+
+```
+| <slug>-dev-loop | `/<slug>-dev-loop` | [{{GITHUB_OWNER}}/{{GITHUB_REPO}}](https://github.com/{{GITHUB_OWNER}}/{{GITHUB_REPO}}) | Autonomous dev loop for {{PROJECT_NAME}} |
+```
+
+Use the actual `GITHUB_OWNER`, `GITHUB_REPO`, and `PROJECT_NAME` values resolved in Step 4. If the skill has no GitHub repo (local-only), put `~/local-skills/<slug>-dev-loop/` in the Source column instead of a link.
+
+Then commit and push:
+
+```bash
+cd ~/my-claude-skills
+git add README.md
+git commit -m "Add <slug>-dev-loop skill"
+git push
+```


### PR DESCRIPTION
## Summary

- Adds Step 6 to `create-dev-loop.md`: after registering a new dev loop skill, append a row to `~/example-skills-catalog/README.md` and push
- Handles both GitHub-hosted skills (link) and local-only skills (path)

## Test plan

- [ ] Run `/create-dev-loop` against a new repo and confirm a row is appended to `~/example-skills-catalog/README.md` with correct name, command, source, and description
- [ ] Confirm commit appears in `dmccoystephenson/example-skills-catalog`

---

_drafted by Claude on behalf of Daniel Stephenson_
