### PR TITLE
Create a private GitHub repo for each new dev loop skill

### DIFF
--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -90,7 +90,8 @@ Create `~/local-skills/<slug>-dev-loop/<slug>-dev-loop.md` using the template be
 Autonomous iterative development loop for {{PROJECT_NAME}}.
 
 **Working directory:** {{REPO_ROOT}}
-**GitHub repo:** {{GITHUB_OWNER}}/{{GITHUB_REPO}}
+**Project repo:** {{GITHUB_OWNER}}/{{GITHUB_REPO}}
+**Skill repo:** dmccoystephenson/<slug>-dev-loop (issues for self-audit findings go here)
 {{#if CLAUDE_MD}}**Project guidance:** read `CLAUDE.md` at the start of each cycle if context is cold.{{/if}}
 
 ---
@@ -295,7 +296,7 @@ Review for any of the following:
 - Project conventions discovered during implementation that the skill should encode
 - Phases that required significantly more or fewer steps than expected
 
-Note any gaps explicitly. If the skill has a home repo, file issues there for human review — do not self-merge changes to the skill.
+Note any gaps explicitly. File issues in the skill repo (`dmccoystephenson/<slug>-dev-loop`) for human review — do not self-merge changes to the skill.
 
 ---
 
@@ -381,15 +382,35 @@ repo-specific choices made (build system, test command, doc sources, reviewer, b
 
 ---
 
-### 6 — Record the skill in my-claude-skills
+### 6 — Create a private GitHub repo for the skill
 
-Open `~/my-claude-skills/README.md` and append a new row to the skills table:
-
-```
-| <slug>-dev-loop | `/<slug>-dev-loop` | [{{GITHUB_OWNER}}/{{GITHUB_REPO}}](https://github.com/{{GITHUB_OWNER}}/{{GITHUB_REPO}}) | Autonomous dev loop for {{PROJECT_NAME}} |
+```bash
+gh repo create <slug>-dev-loop --private --description "Autonomous dev loop skill for {{PROJECT_NAME}}"
 ```
 
-Use the actual `GITHUB_OWNER`, `GITHUB_REPO`, and `PROJECT_NAME` values resolved in Step 4. If the skill has no GitHub repo (local-only), put `~/local-skills/<slug>-dev-loop/` in the Source column instead of a link.
+Initialize the local skill directory as a git repo, commit the skill file, and push:
+
+```bash
+cd ~/local-skills/<slug>-dev-loop
+git init
+git branch -m main
+git remote add origin https://github.com/$(gh api user -q .login)/<slug>-dev-loop.git
+git add <slug>-dev-loop.md
+git commit -m "Initial commit: <slug>-dev-loop skill"
+git push -u origin main
+```
+
+The GitHub repo serves as the issue tracker for self-audit findings. When the generated skill's Phase 9 says "file issues there for human review", issues go here.
+
+---
+
+### 7 — Record the skill in my-claude-skills
+
+Open `~/my-claude-skills/README.md` and append a new row to the skills table using the GitHub repo created in Step 6:
+
+```
+| <slug>-dev-loop | `/<slug>-dev-loop` | [dmccoystephenson/<slug>-dev-loop](https://github.com/dmccoystephenson/<slug>-dev-loop) | Autonomous dev loop for {{PROJECT_NAME}} |
+```
 
 Then commit and push:
 


### PR DESCRIPTION
## Summary

- Adds Step 6: creates a private GitHub repo (`<slug>-dev-loop`), initializes the local skill dir as a git repo, and pushes the skill file
- Renames old Step 6 → Step 7 (record in example-skills-catalog), now always uses the GitHub link since every skill has a repo
- Updates the generated skill template header to show both the project repo and the skill repo
- Tightens Phase 9 self-audit: "file issues in the skill repo" is now definitive, not conditional

## Test plan

- [ ] Run `/create-dev-loop` against a new repo and confirm a private `<slug>-dev-loop` GitHub repo is created
- [ ] Confirm skill file is pushed to that repo
- [ ] Confirm `example-skills-catalog` README gets a row with the correct GitHub link

---

_drafted by Claude on behalf of Daniel Stephenson_
