### PR TITLE
Fix template/doc accuracy: CLAUDE_MD table entry, README steps, unconditional self-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Running `/create-dev-loop` in any repo will:
 2. **Compile** a repo-specific profile — build command, test command, branch prefix, reviewer, doc sources, code patterns
 3. **Generate** a ready-to-use `<slug>-dev-loop` skill file at `~/local-skills/<slug>-dev-loop/`
 4. **Register** it as a slash command at `~/.claude/commands/<slug>-dev-loop.md`
+5. **Create** a private GitHub repo (`<slug>-dev-loop`) to serve as the issue tracker for self-audit findings
+6. **Record** the skill in `~/my-claude-skills/README.md` for discoverability
 
 The generated skill drives a 10-phase loop: triage → work selection → implementation → PR → review → address comments → doc check → merge → self-audit → repeat.
 

--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -194,7 +194,10 @@ Request a review:
 gh pr edit <number> --add-reviewer {{REVIEWER}}
 \`\`\`
 
-If the command errors (reviewer not configured), perform a self-review instead:
+If the command errors (reviewer not configured), proceed directly to the self-review below.
+
+{{/if}}
+Perform a self-review:
 
 1. Read the full diff:
    \`\`\`bash
@@ -217,7 +220,6 @@ If the command errors (reviewer not configured), perform a self-review instead:
    \`\`\`
    Use the actual file line number for `line` (read the source, do not guess from diff position). Use `"side": "RIGHT"` for added or changed lines. Omit `comments` entirely if there are no lines worth anchoring. If there are no findings, post `"Self-review: no issues found."` with an empty comments array.
 4. Proceed to Phase 5 — address your own comments in Phase 6.
-{{/if}}
 
 ---
 
@@ -311,7 +313,7 @@ Return to Phase 1.
 **Tests fail during implementation:** diagnose; never skip or use `--no-verify`.
 **Tests fail after addressing a comment:** same rule.
 **A review comment is a false positive:** reply with evidence, do not apply the change.
-{{#if REVIEWER}}**Reviewer addition fails:** perform the self-review described in Phase 4. Do not skip to Phase 5 without leaving comments — the self-review is the substitute, and Phase 6 addresses those comments like any other review.{{/if}}
+{{#if REVIEWER}}**Reviewer addition fails:** proceed to the self-review step in Phase 4. Do not skip to Phase 5 without posting self-review comments — Phase 6 addresses those comments like any other review.{{/if}}
 **Branch is behind main or has a merge conflict at Phase 8:** rebase onto main, re-run tests, and force-push before retrying the merge:
 \`\`\`bash
 git fetch origin
@@ -350,6 +352,7 @@ Use findings from Step 2 to substitute each `{{placeholder}}`:
 | `CODE_PATTERNS` | Bullet list from CLAUDE.md; omit section if no CLAUDE.md |
 | `TEST_GUIDANCE` | Framework name, naming convention, file location, any fake/mock patterns |
 | `DOC_CHECK_TABLE` | One row per documentation source of truth identified in Step 2 |
+| `CLAUDE_MD` | True if `CLAUDE.md` exists in the repo root (`ls CLAUDE.md 2>/dev/null`); controls whether the "Project guidance" line appears in the skill header |
 
 For `SCAN_CHECKLIST`, always include these universal items plus any repo-specific ones:
 - Missing tests on new public methods


### PR DESCRIPTION
## Summary

- Add `CLAUDE_MD` row to the Step 4 substitution table — the `{{#if CLAUDE_MD}}` conditional in the template had no guidance on how to resolve it
- Update README "What it does" to list all 7 steps; previously omitted Steps 6 (create GitHub repo) and 7 (record in example-skills-catalog)
- Move Phase 4 self-review outside `{{#if REVIEWER}}` so it is always present; repos with no configured reviewer previously had no code review step at all

## Test plan

- [ ] Open `create-dev-loop.md` and verify `CLAUDE_MD` appears in the substitution table
- [ ] Verify Phase 4 template shows `Perform a self-review:` unconditionally, with the reviewer-addition block above it conditionally
- [ ] Open `README.md` and verify "What it does" lists 6 items including create-repo and record-skill
- [ ] No unresolved `{{placeholders}}` remain (every placeholder in the template now has a substitution table row)

Closes #5
Closes #6
Closes #7

---

_drafted by Claude on behalf of Daniel Stephenson_
