### PR TITLE
CLAUDE.md: pointer to promotion-with-retrofit checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ Changes to **how repos are explored or how skills are structured** belong in `cr
 
 Repo-specific findings (build commands, reviewer names, branch prefixes) belong **only** in the generated skill, never back-ported here.
 
+## Promoting a rule into the template
+
+When you add a new rule to `create-dev-loop.md` because the same lesson keeps showing up in multiple skills' self-audits, **also open retrofit PRs against every existing skill that predates the change.** The template only fixes drift forward; existing skills will silently lag until their next self-audit cycle. See the "Promoting a carry-over into the template" section of [`my-claude-skills/CONVENTIONS.md`](https://github.com/dmccoystephenson/my-claude-skills/blob/main/CONVENTIONS.md) for the checklist.
+
 ## Testing changes
 
 There is no automated test suite. Validate changes by running `/create-dev-loop` against a real repo and confirming:


### PR DESCRIPTION
## Summary
- Adds a short "Promoting a rule into the template" section to CLAUDE.md pointing at the new checklist in [example-skills-catalog/CONVENTIONS.md](https://github.com/dmccoystephenson/example-skills-catalog/blob/main/CONVENTIONS.md)
- Without this pointer, the next person editing the template will look at CLAUDE.md (the most local doc) and miss the retrofit step
- Pairs with example-skills-catalog#3

## Test plan
- [ ] Visual review of the new section
- [ ] Confirm the link to CONVENTIONS.md is correct

---

_drafted by Claude on behalf of Daniel Stephenson_
