### PR TITLE
Promote 'verify each Closes #N' to template Phase 4

### DIFF
--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -187,6 +187,8 @@ Fix all failures before proceeding. Never skip tests or bypass hooks.
 
 ### Phase 4 — PR
 
+**Before pushing, verify each `Closes #N`.** For every issue number you plan to reference, run `gh issue view <N>` and confirm the title and body match what this PR does. Numbers carried forward from earlier session context or from summarized prior cycles are a common source of wrong-issue auto-closes — if a referenced issue describes unrelated work, omit the `Closes` reference and either file a new issue or note `No tracking issue — gap found during triage.` in the PR body.
+
 \`\`\`bash
 git push -u origin {{BRANCH_PREFIX}}/<short-description>
 gh pr create --title "..." --body "..."


### PR DESCRIPTION
## Summary

Adds a universal pre-push step to Phase 4 of the generated dev-loop template: before pushing, run `gh issue view <N>` for every `Closes #N` to confirm the issue title/body matches the PR's actual work. Numbers carried forward from earlier session context or summarized cycles are a known source of wrong-issue auto-closes — connected to RESEARCH.md §4 (context rot in long-horizon runs).

The pattern was first encoded in `example-a-dev-loop`; this promotion makes it universal across all newly generated dev-loop skills.

Closes #23

## Test plan

- [x] No new `{{placeholders}}` introduced; substitution table unchanged
- [x] Edit is prose-only (no fenced code block), so no triple-backtick escape concern
- [x] Phase numbers in template unchanged (still 1–10); README "What it does" count unchanged
- [x] Confirmed the new step renders cleanly in context (read lines 188–200 after the edit)

Retrofit PRs against `example-l-dev-loop`, `example-q-dev-loop`, `example-a-dev-loop` (canonical reword), and `example-h-dev-loop` are tracked separately per the promotion-with-retrofit checklist in CLAUDE.md.

---

_drafted by Claude on behalf of Daniel Stephenson_
