### PR TITLE
Track implementation outcomes back into RESEARCH.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ When proposing a change to `create-dev-loop.md`, the generated template, or a ph
 - If no finding applies, say so explicitly — honest "we don't know" beats false confidence.
 - If new research surfaces that affects the project, add the finding to `RESEARCH.md` as part of the same PR (or a precursor one). Include citation, key numbers, confidence level, and the implication for this project.
 - If a finding turns out to be superseded or contradicted, update it in place — don't silently leave stale claims.
+- If your PR implements a finding from `RESEARCH.md`, also add (or update) an **Implementations** entry under that finding with the PR number, the date shipped, and an observed-effect placeholder. See `RESEARCH.md` "How to use this document" for the entry format.
 
 ## Testing changes
 

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -7,6 +7,12 @@ This document records the empirical findings that inform the design of `create-d
 - **When proposing a change** to `create-dev-loop.md`, the generated skill template, or a phase definition: cite the relevant finding(s) below in the PR description. If no finding applies, say so explicitly rather than acting on intuition.
 - **When new research surfaces** that affects the project's design, add a finding here. Include the citation, key numbers, confidence level, and the specific implication for this project.
 - **When a finding is superseded** by stronger evidence or contradicted by replication, update it in place — don't silently leave stale claims. Strike-through or "Superseded by:" notes are preferred over deletion when the change in understanding is itself informative.
+- **When a finding gets implemented**, add an entry under that finding's **Implementations** subsection recording the PR number, the date shipped, and an observed-effect placeholder. The format is:
+  ```
+  **Implementations.**
+  - PR #N (one-line summary): shipped YYYY-MM-DD. Observed effect: pending — needs N cycles of data.
+  ```
+  After a few cycles of running the loop, return and replace "pending" with the actual observation (rate of caught issues, false positives, regressions). The point is to close the loop between research-grounded predictions and what we actually see.
 - **First-party sources** (Anthropic, OpenAI, vendor research with numbers) count as evidence but must be flagged as first-party so readers can weight them appropriately.
 - **Confidence levels**: `high` = replicated across multiple independent studies; `medium` = one well-cited study, plausible; `low` = single paper, contested, or inferred from adjacent literature.
 
@@ -34,6 +40,9 @@ Last reviewed: 2026-05-25.
 - Replace free-form review with an objective yes/no rubric ("Does the diff modify any file outside the issue scope?") rather than quality judgments ("Is this good code?").
 - Frame the review adversarially ("Find one bug a reviewer will flag") to partially counter sycophancy and self-preference bias.
 - Consider performing self-review in a fresh context so the agent doesn't anchor on its own reasoning trace.
+
+**Implementations.**
+- PR #15 (Reframe self-review as rubric-based and CI-grounded): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. First applied to PR #26 (one cycle, all rubric items PASS); too early to tell whether the rubric catches real defects that free-form review would miss.
 
 ---
 
@@ -92,6 +101,9 @@ Last reviewed: 2026-05-25.
 - Set an abort-and-file-gap-issue budget (tool calls or token count). If the loop hasn't converged by then, restart with fresh context rather than push through; the half-life model predicts persistence past a budget is strictly worse.
 - The "agentic-level" failures from finding #2 (license violations, instruction misalignment) reinforce the need to re-state scope rules at each phase, not only once at the top.
 
+**Implementations.**
+- PR #26 (Promote 'verify each Closes #N' to template Phase 4): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Narrow application of "re-state scope at boundaries" — verifies issue numbers against actual issue content before push, countering stale-context anchoring.
+
 ---
 
 ### 5. Reflection iterations plateau early; more is not better
@@ -108,6 +120,9 @@ Last reviewed: 2026-05-25.
 **Implication for create-dev-loop.**
 - Cap the self-review → fix → self-review cycle at 2 iterations unless the trigger is an external signal (CI failure, reviewer comment).
 - Distinguish *external* comments (good iteration signal — keep iterating until resolved) from *internal* self-critique (cap iterations, no re-critique loops).
+
+**Implementations.**
+- PR #15 (Reframe self-review as rubric-based and CI-grounded): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Adds the explicit "one intrinsic-critique pass per PR" cap and the external-vs-internal-signal distinction to the template's Phase 4 and Phase 6.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the feedback loop between research-grounded predictions and what we actually observe by:

- Adding an **Implementations** convention to RESEARCH.md's "How to use this document" section: when a finding gets implemented, record the PR + ship date + observed-effect placeholder under the finding.
- Adding a corresponding bullet to CLAUDE.md's "Grounding work in research" so the rule appears at the same point of friction (PR authoring) where forward citations are already required.
- Retroactively populating Implementations entries for findings that have already been acted on:
  - §1 (self-critique with external signal) → PR #15 (rubric-based self-review)
  - §4 (long-horizon decay, context rot) → PR #26 (verify each `Closes #N` before push) — a narrow instance of "re-state scope at boundaries"
  - §5 (reflection iterations plateau) → PR #15 (one-intrinsic-critique-pass cap)

The "observed effect" column starts at "pending" — replacing it with real numbers requires running multiple cycles, which only becomes routine once #24 (structured self-audit) lands. This PR establishes the data-recording habit so the column has somewhere to go.

Closes #25

## Test plan

- [x] RESEARCH.md "How to use" section gains the Implementations convention with format example
- [x] CLAUDE.md "Grounding work in research" gains a matching bullet pointing at RESEARCH.md
- [x] Three retroactive entries placed under §1, §4, §5 — confirmed by `grep -n "^\*\*Implementations\." RESEARCH.md` returning lines 44/104/124 (one per finding)
- [x] No changes to `create-dev-loop.md` template; substitution table unchanged
- [x] PR #15 ship date 2026-05-25 confirmed via `gh pr view 15 --json mergedAt`
- [x] Per the rule shipped in PR #26, ran `gh issue view 25` and confirmed issue title/body match this PR's work

## Note on AC #4

Issue #25's fourth AC ("at least one updated outcome entry, i.e. not just 'pending'") cannot be honestly satisfied yet — none of the three implementations has been measured across enough cycles to replace "pending" with a real observation. Marking that AC explicitly as deferred rather than fabricating an outcome.

---

_drafted by Claude on behalf of Daniel Stephenson_
