### PR TITLE
Bias triage and batching toward higher-merge-rate issue types

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -61,6 +61,9 @@ Last reviewed: 2026-05-25.
 - The merge phase should require green CI as a non-negotiable gate, not self-review approval alone.
 - The generated skill should include explicit human off-ramps: conditions under which the agent must stop and request review rather than auto-merge.
 
+**Implementations.**
+- PR #29 (Bias triage and batching toward higher-merge-rate issue types): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Adds a Phase 2 tiebreaker preferring documentation → CI/build → small refactors → bug fixes → performance, with stronger weighting in early cycles. Targets the merge-rate gradient by issue type; does not yet address the LOC/files ceilings (issue #17 is the structural-gates follow-up).
+
 ---
 
 ### 3. SWE-bench Verified is inflated; localization is the real bottleneck
@@ -157,6 +160,9 @@ Last reviewed: 2026-05-25.
 **Implication for create-dev-loop.**
 - The triage phase should emit its classification reasoning to the PR description so a human can audit which issues were skipped and why — don't silently filter.
 - Use triage for batching coherence (group related issues) rather than for value judgment ("this is a bad issue"). The literature supports the former better.
+
+**Implementations.**
+- PR #29 (Bias triage and batching toward higher-merge-rate issue types): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Adds a Phase 1 \"Record skip reasons\" instruction so triage decisions are auditable rather than silent. Does not yet address the deeper \"use triage for batching coherence, not value judgment\" implication beyond the existing 0–3 issue coherent-batch ceiling.
 
 ---
 

--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -140,6 +140,8 @@ Scan for improvements not yet tracked:
 - Title accurately describes what the body says
 - Every claim in the body still holds after re-reading the source
 
+**Record skip reasons.** Any open issue that exists at triage time but is not picked for this cycle's work must have its skip reason recorded — either in the PR body of whatever this cycle does pick, or as a comment on the skipped issue. The point is auditability: a human (or a later self-audit) can see which issues were intentionally deferred and why, rather than reading silence as a value judgment. Per RESEARCH.md §7, LLM-based issue triage is a useful first-pass filter but not a final decision — surfacing the filter's reasoning preserves human oversight.
+
 ---
 
 ### Phase 2 — Work selection
@@ -152,6 +154,10 @@ Choose 0–3 issues to implement as a coherent PR:
 - **3** only when all three are small and clearly independent.
 
 When issues have a dependency relationship, implement the foundation first.
+
+**Tiebreaker rule.** When choosing between issues of comparable scope and no dependency relationship, bias toward (in descending preference): documentation fixes → CI/build fixes → small refactors → bug fixes → performance work. Per RESEARCH.md §2, autonomous-agent PRs merge at substantially higher rates for the earlier categories. This is a soft tiebreaker, not a hard exclusion — a clearly-scoped bug fix is still better than no progress, and coherent-batch grouping still takes precedence when it applies.
+
+**Early-cycle bias.** For the first 3–5 cycles after a new dev-loop skill is generated for a repo, weight the tiebreaker more strongly toward documentation and build fixes — the agent has minimal prior context for harder work. Once the loop has shipped several cycles successfully, the bias relaxes. This is a preference, not a rule; an explicit user instruction overrides it.
 
 Include `Closes #N` in the PR body for each resolved issue so GitHub auto-closes on merge.
 


### PR DESCRIPTION
## Summary

Adds two paragraphs to the generated dev-loop template:

1. **Phase 1 — Record skip reasons.** When triage filters out an open issue, record the skip reason in the chosen PR's body or as a comment on the skipped issue. Per RESEARCH.md §7, LLM-based issue triage is useful as a filter but not as a final decision — surfacing the filter's reasoning preserves human oversight.

2. **Phase 2 — Tiebreaker + early-cycle bias.** When choosing between issues of comparable scope with no dependency relationship, prefer (in descending order): documentation fixes → CI/build fixes → small refactors → bug fixes → performance work. Per RESEARCH.md §2, autonomous-agent PRs merge at substantially higher rates for the earlier categories. The tiebreaker is soft; coherent-batch grouping still wins when it applies. Early cycles (the first 3–5 after a new dev-loop skill is generated) weight the tiebreaker more strongly.

Closes #20

## Test plan

- [x] Phase 1 has explicit \"Record skip reasons\" instruction (line 142)
- [x] Phase 2 has tiebreaker rule with one-sentence rationale + RESEARCH.md cross-reference (line 156)
- [x] Phase 2 marks early-cycle bias as soft preference, not hard rule (line 158)
- [x] No new `{{placeholders}}` introduced; substitution table unchanged (placeholder count: 19, same as before)
- [x] Phase numbering unchanged (still 1–10); README \"What it does\" count unchanged
- [x] Per the rule shipped in PR #26, ran `gh issue view 20` and confirmed title/body match

## Note on Phase 1's RESEARCH.md cross-reference

The skip-reason instruction cites RESEARCH.md §7 (LLM-based issue triage accuracy 70–85%). Per the CLAUDE.md rule shipped in PR #27, this PR should also add an Implementations entry under §7 — but §7's specific implications were \"emit triage reasoning to the PR description\" and \"use triage for batching coherence rather than value judgment,\" both of which this PR directly implements. Adding an Implementations entry now.

---

_drafted by Claude on behalf of Daniel Stephenson_
