### PR TITLE
Add pre-edit localization verification and pre-merge regression gate

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -84,6 +84,9 @@ Last reviewed: 2026-05-25.
 - Add explicit localization verification before edit: require the agent to enumerate target files and confirm they contain the named surface area from the issue before writing changes.
 - Add a regression check before merge: require a new or updated test for any bug-fix issue, not just "existing tests pass."
 
+**Implementations.**
+- PR #31 (Localization + regression gates): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Adds a Phase 3 \"Localization verification\" step (enumerate files, `test -f`, grep for the named surface area) and a Phase 8 regression gate (bug-fix `Closes #N` requires a new/modified test or validation step). Generalized to projects whose external anchor is manual validation rather than tests.
+
 ---
 
 ### 4. Long-horizon agent runs decay exponentially; context rot is the practical limit

--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -169,6 +169,13 @@ git checkout -b {{BRANCH_PREFIX}}/<short-description>
 
 ### Phase 3 — Implementation
 
+**Localization verification.** Before writing any code, list the files this PR intends to modify and verify each one:
+
+1. **Confirm the file exists.** `test -f <path>` or `ls <path>`.
+2. **Confirm the surface area is present.** For each file, grep for the symbol, heading, config key, or behavior named in the issue. If the issue says "the `validatePermission` method swallows the exception", run `grep -n 'validatePermission' <path>` and confirm the named entity is present. If it isn't, stop and re-triage — the localization is wrong and editing here would produce a misfire.
+
+This catches the dominant agent failure mode on uncontaminated benchmarks: finding the right file to edit, not the patch itself (RESEARCH.md §3).
+
 {{#if CODE_PATTERNS}}
 Follow project conventions:
 {{CODE_PATTERNS}}
@@ -328,6 +335,8 @@ Only proceed when a complete pass finds nothing wrong.
 ---
 
 ### Phase 8 — Merge
+
+**Regression gate.** For each issue in `Closes #N` that is a bug fix or describes incorrect behavior, verify the diff includes a new or modified test (or, for projects whose external anchor is manual validation, a new validation step) that exercises the fix. If absent, do not merge — either add the regression coverage or reclassify the issue. Per RESEARCH.md §3, regression evidence is the only way to distinguish a real fix from a coincidental patch.
 
 **Do-not-auto-merge path check.** Before invoking `gh pr merge`, list the files this PR modifies and check them against the do-not-auto-merge list. If any modified path matches, do not merge automatically — leave the PR open and report to the user for manual review.
 


### PR DESCRIPTION
## Summary

Two structural additions to the generated dev-loop template, grounded in RESEARCH.md §3 (localization is the real bottleneck on uncontaminated benchmarks):

1. **Phase 3 — Localization verification.** Before writing any code, list the target files and verify each with `test -f` + a `grep` for the named surface area from the issue. If the issue says the bug is in `validatePermission` and grep finds nothing, the localization is wrong — stop and re-triage.

2. **Phase 8 — Regression gate.** For each `Closes #N` that describes a bug or incorrect behavior, require a new/modified test (or validation step, for projects whose external anchor is manual validation) in the diff. Hardens the Phase 4 Tests-fix rubric item into a merge-time gate.

Generalized cleanly with the `{{EXTERNAL_SIGNAL_LABEL}}` infrastructure shipped in PR #28: test-having repos check for a new test, no-CI repos check for a new validation step.

Closes #18

## Test plan

- [x] Phase 3 begins with a \"Localization verification\" step listing 2 sub-steps (existence + surface-area grep) with a concrete example (RESEARCH.md §3 cross-reference)
- [x] Phase 8 has a regression-test gate as the first block, before the do-not-auto-merge check
- [x] No new `{{placeholders}}` (placeholder count unchanged); the regression gate reuses `{{EXTERNAL_SIGNAL_LABEL}}` indirectly via the prose
- [x] This PR's own localization was verified: target file `create-dev-loop.md` exists, contains \"Phase 3 — Implementation\" and \"Phase 8 — Merge\" headings
- [x] Diff size 12 LOC across 2 files — well under the soft ceiling (400 LOC / 10 files) shipped in PR #30
- [x] Per the rule shipped in PR #26, ran `gh issue view 18` and confirmed title/body match
- [x] Per the rule shipped in PR #27, added an Implementations entry under RESEARCH.md §3
- [x] Per the gate shipped in PR #30, ran `git diff --name-only origin/main...HEAD` and confirmed no matches against do-not-auto-merge list

## Fixture-validation note

#18's test plan asks for \"a fixture issue where the agent would naively localize to the wrong file\" — same as #17's fixture ask, this requires fixture tooling that doesn't exist. The localization check is currently authority-based, not enforced. A pre-edit check could be wired into a hook in the future.

---

_drafted by Claude on behalf of Daniel Stephenson_
