### PR TITLE
Add template-version header to generated skills for drift detection

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -186,6 +186,9 @@ Last reviewed: 2026-05-25.
 - Consider adding a "skill version + tested-against-model" header to generated skills, so a future self-audit can distinguish drift from a fresh bug.
 - Consider periodic regression checks: dry-run the generated skill against a known-good fixture repo and compare output to a recorded baseline. The `dpm-dev-loop` / `herald-dev-loop` references could serve as fixtures.
 
+**Implementations.**
+- PR #33 (Template-version header for drift detection): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Adds `<!-- template-version: SHA -->` and `<!-- generated-at: ISO-timestamp -->` HTML comments to the top of every newly generated skill, plus `{{TEMPLATE_VERSION}}` and `{{GENERATED_AT}}` rows to the Step 4 substitution table. Implements the second bullet of this finding's implications; the periodic regression-check (third bullet) is a separate future change. The drift-detection step in `cdl-dev-loop` Phase 9 is also deferred — it belongs in the cdl-dev-loop repo, not here.
+
 ---
 
 ## Already aligned with the evidence

--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -89,6 +89,9 @@ Compile findings into these answers before writing the skill:
 Create `~/local-skills/<slug>-dev-loop/<slug>-dev-loop.md` using the template below, substituting all `{{placeholders}}` with findings from Step 2. Remove any section that does not apply (e.g. no changelog → remove changelog row from doc check table).
 
 ```markdown
+<!-- template-version: {{TEMPLATE_VERSION}} -->
+<!-- generated-at: {{GENERATED_AT}} -->
+
 # <slug>-dev-loop
 
 Autonomous iterative development loop for {{PROJECT_NAME}}.
@@ -484,6 +487,8 @@ Use findings from Step 2 to substitute each `{{placeholder}}`. The table below c
 | `CLAUDE_MD` | True if `CLAUDE.md` exists in the repo root (`ls CLAUDE.md 2>/dev/null`); controls whether the "Project guidance" line appears in the skill header |
 | `SELF_REVIEW_RUBRIC` | Repo-specific objective yes/no rubric items for the Phase 4 self-review. Each item must be answerable from the diff or a command output, not from judgment. Add items only when the repo has anti-patterns or invariants not already covered by the universal items in Phase 4. Examples: "Every `@Override` matches a real superclass method" (Java); "No `console.log` in committed code" (JS); "Every new permission appears in `plugin.yml`" (Bukkit plugin). Format as one indented Markdown bullet per item: `   - **<short-name>:** <objective condition>`. Omit the conditional block entirely if no repo-specific items apply. |
 | `DO_NOT_AUTO_MERGE` | Repo-specific paths that require human review before merge (in addition to the universal entries in Phase 8). Common entries: `plugin.yml` (Bukkit plugins), `pom.xml` (Maven projects), `Cargo.toml` (Rust), `package.json` (Node), the project's main config or schema file. Format as one Markdown bullet per entry, with backticks around the path or glob and a brief rationale after an em-dash. Omit the conditional block entirely if no repo-specific entries apply. |
+| `TEMPLATE_VERSION` | Short commit SHA of the `create-dev-loop` repo at generation time. Capture with `git -C <path-to-create-dev-loop> rev-parse --short HEAD`. Becomes part of an HTML comment at the top of the generated skill so future cycles can detect template drift. |
+| `GENERATED_AT` | ISO-8601 UTC timestamp at generation time. Capture with `date -u +%Y-%m-%dT%H:%M:%SZ`. Pairs with `TEMPLATE_VERSION` in the HTML-comment header. |
 
 For `SCAN_CHECKLIST`, always include these universal items plus any repo-specific ones:
 - Missing tests on new public methods


### PR DESCRIPTION
## Summary

Every newly generated `<slug>-dev-loop` skill now starts with two HTML comments recording the template state at generation time:

```
<!-- template-version: {{TEMPLATE_VERSION}} -->
<!-- generated-at: {{GENERATED_AT}} -->
```

`TEMPLATE_VERSION` resolves to the short SHA of the `create-dev-loop` repo at generation time (`git -C <path-to-create-dev-loop> rev-parse --short HEAD`); `GENERATED_AT` resolves to an ISO-8601 UTC timestamp. Both are HTML comments so they don't render in the skill's prose but are grep-able for drift detection.

The substitution-table descriptions tell the generating agent exactly how to derive each value at Step 4 time — the issue mentioned Step 6, but Step 4 is the natural integration point (where ALL placeholders are populated). The end behavior matches the issue's intent.

Closes #22

## Test plan

- [x] Generated skill template now opens with the two HTML comments (lines 92–93 of `create-dev-loop.md`)
- [x] Substitution table has new rows for `TEMPLATE_VERSION` and `GENERATED_AT` with concrete commands for capture
- [x] `grep -oP '\\{\\{[A-Z_]+\\}\\}'` confirms both placeholders appear in the template AND have substitution-table rows — placeholder-consistency invariant holds
- [x] HTML-comment form (`<!-- ... -->`) chosen so the comments don't render in skill output but remain grep-able
- [x] Localization verified: `# <slug>-dev-loop` heading at line 92 before edit; insertion above it lands the comments at the very top of the rendered skill
- [x] Diff 8 LOC, 2 files — well under scope ceiling (PR #30)
- [x] Per the rule shipped in PR #26, ran `gh issue view 22` and confirmed title/body match
- [x] Per the rule shipped in PR #27, added an Implementations entry under RESEARCH.md §8
- [x] Do-not-auto-merge check (PR #30): modified files `create-dev-loop.md`, `RESEARCH.md`; no matches

## Deferred AC

- AC #4 (`example-h-dev-loop` Phase 9 drift-detection step) belongs in the `dmccoystephenson/example-h-dev-loop` repo, not this one — Phase 9 of `example-h-dev-loop` explicitly forbids self-modification from inside a cycle. Filing a follow-up issue against that repo is the right channel; recording it here as deferred.

---

_drafted by Claude on behalf of Daniel Stephenson_
