### PR TITLE
Structure Phase 9 self-audit prompts and label gap issues

### DIFF
--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -43,6 +43,7 @@ Last reviewed: 2026-05-25.
 
 **Implementations.**
 - PR #15 (Reframe self-review as rubric-based and CI-grounded): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. First applied to PR #26 (one cycle, all rubric items PASS); too early to tell whether the rubric catches real defects that free-form review would miss.
+- PR #34 (Structure Phase 9 self-audit prompts and label gap issues): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Extends the rubric-over-free-form pattern from Phase 4 (self-review) to Phase 9 (self-audit), with a 6-item structured checklist and a 5-label taxonomy for filed gap issues.
 
 ---
 
@@ -131,6 +132,7 @@ Last reviewed: 2026-05-25.
 
 **Implementations.**
 - PR #15 (Reframe self-review as rubric-based and CI-grounded): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Adds the explicit "one intrinsic-critique pass per PR" cap and the external-vs-internal-signal distinction to the template's Phase 4 and Phase 6.
+- PR #34 (Structure Phase 9 self-audit prompts and label gap issues): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Structured rubric for the retrospective phase mirrors the Phase 4 self-review structure; same plateau-by-iteration-2 logic argues for capping retrospective re-runs at one pass.
 
 ---
 

--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -401,19 +401,30 @@ gh issue close <number> --comment "Resolved in PR #<n>."
    gh issue list --repo dmccoystephenson/<slug>-dev-loop --state open
    \`\`\`
 
-2. **Reflect on the cycle just completed.** Review for any of the following:
-   - **Identity drift** — did this cycle act in accordance with the identity stated at the top of this skill? If not, that's the most important issue to file.
-   - Instructions that were ambiguous or caused a wrong first attempt
-   - Edge cases encountered that are not covered in this skill
-   - Project conventions discovered during implementation that the skill should encode
-   - Phases that required significantly more or fewer steps than expected
+2. **Run the self-audit rubric.** For each item, mark PASS / FAIL / "no signal this cycle" with a one-line justification grounded in the cycle's actual events:
+   - **Identity drift:** did this cycle act in accordance with the identity stated at the top of this skill?
+   - **Instruction clarity:** did any step require interpretation or produce a wrong first attempt?
+   - **Edge case coverage:** did any failure mode arise that the Edge cases section does not cover?
+   - **Phase friction:** did any phase require significantly more or fewer steps than expected?
+   - **Drift candidates:** did any decision feel like it should be encoded in `create-dev-loop.md` rather than re-discovered each cycle?
+   - **External-signal quality:** did `{{EXTERNAL_SIGNAL_LABEL}}` actually catch the kinds of issues it's supposed to catch this cycle?
 
-3. **For each gap not already tracked, file an issue:**
+   Per RESEARCH.md §1 and §5, structured rubrics outperform free-form prompts for LLM critique — the same logic that grounds the Phase 4 self-review applies to this retrospective.
+
+3. **For each FAIL item not already tracked, file a labeled issue** so triage knows where the gap belongs:
    \`\`\`bash
    gh issue create --repo dmccoystephenson/<slug>-dev-loop \
      --title "<short description of the gap>" \
-     --body "<what was ambiguous or missing, and suggested instruction text>"
+     --body "<what was ambiguous or missing, and suggested instruction text>" \
+     --label <one-of: template-rule | repo-specific | edge-case | research-gap | process>
    \`\`\`
+
+   Label taxonomy:
+   - `template-rule` — should be promoted into `create-dev-loop.md`
+   - `repo-specific` — belongs only in this skill
+   - `edge-case` — should be added to Edge cases
+   - `research-gap` — new finding worth a RESEARCH.md entry
+   - `process` — meta-issue about how the loop runs
 
 4. **Do not implement or merge changes to the skill itself** — file issues only so a human reviews and approves skill edits.
 
@@ -540,6 +551,21 @@ git push -u origin main
 ```
 
 The GitHub repo serves as the issue tracker for self-audit findings. When the generated skill's Phase 9 says "file issues there for human review", issues go here.
+
+Create the gap-issue labels used by Phase 9 so they exist when the first cycle runs:
+
+```bash
+OWNER=$(gh api user -q .login)
+for entry in \
+  "template-rule:FFD700:Should be promoted into create-dev-loop.md" \
+  "repo-specific:0E8A16:Belongs only in this skill" \
+  "edge-case:FBCA04:Should be added to Edge cases" \
+  "research-gap:B60205:New finding worth a RESEARCH.md entry" \
+  "process:CFD3D7:Meta-issue about how the loop runs"; do
+  IFS=: read -r name color desc <<< "$entry"
+  gh label create "$name" --color "$color" --description "$desc" --repo "$OWNER/<slug>-dev-loop"
+done
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Three changes to the generated dev-loop template:

1. **Phase 9 self-audit becomes a structured rubric.** Replaces the free-form bullet list with a 6-item rubric (identity drift, instruction clarity, edge case coverage, phase friction, drift candidates, external-signal quality) — each scored PASS / FAIL / no-signal with a one-line justification. Mirrors the Phase 4 self-review structure shipped in PR #15. Grounded in RESEARCH.md §1 and §5 (structured rubrics outperform free-form for LLM critique).

2. **Filed gap issues now carry a label** from a 5-label taxonomy: `template-rule`, `repo-specific`, `edge-case`, `research-gap`, `process`. Makes triage faster and surfaces patterns across child-skill repos.

3. **Step 6 creates the labels** at repo-creation time so they exist when the first cycle's Phase 9 fires. Uses a single `for` loop over a colon-delimited list of `name:color:description` entries.

Closes #24

## Test plan

- [x] Phase 9 step 2 replaced with structured rubric (6 items, each with explicit FAIL/PASS/no-signal scoring)
- [x] Phase 9 step 3 updated to require `--label` argument and lists the 5-label taxonomy inline
- [x] Step 6 has a label-creation loop with the 5 labels, hex colors, and descriptions matching the Phase 9 taxonomy verbatim
- [x] No new `{{placeholders}}` introduced (universal rule — placeholder count still 22 with `TEMPLATE_VERSION` and `GENERATED_AT` from PR #33)
- [x] Diff 44 lines across 2 files (net +28) — well under scope ceiling
- [x] Localization verified: \"Phase 9 — Self-audit\" heading at line 397, \"### 6 — Create a private GitHub repo\" at line 535
- [x] Per the rule shipped in PR #26, ran `gh issue view 24` and confirmed title/body match
- [x] Per the rule shipped in PR #27, added Implementations entries under RESEARCH.md §1 and §5
- [x] Do-not-auto-merge check (PR #30): modified `create-dev-loop.md`, `RESEARCH.md`; no matches

## Note on label taxonomy duplication

The taxonomy is listed in two places: Phase 9 (where the agent picks one) and Step 6 (where the agent creates the labels). They must stay in sync. A future PR could DRY this — e.g. a single placeholder `{{GAP_LABEL_TAXONOMY}}` — but that's overengineering for 5 entries. Listed in both spots verbatim; renaming-siblings-together rule applies if anyone changes the names.

---

_drafted by Claude on behalf of Daniel Stephenson_
