### PR TITLE
Add update mode: re-derive existing dev-loop skills from current template

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ The generated skill drives a 10-phase loop: triage → work selection → implem
 /create-dev-loop
 ```
 
-Run this from inside any git repository. If a skill already exists for the repo, you'll be asked whether to overwrite it.
+Run this from inside any git repository. If a skill already exists for the repo, you'll be asked to choose:
+
+- **update** *(default)* — re-derive the skill from the current template and current repo state, then show a diff before overwriting. Use this to pull in template improvements without re-creating the GitHub repo or `my-claude-skills` entry. Aborts if the local skill directory has uncommitted changes.
+- **overwrite** — full regeneration, idempotently re-asserting the repo and registry entry.
+- **cancel** — exit without changes.
 
 The skill reports the command name and a summary of the choices made (build system, test runner, doc sources, reviewer, branch prefix) when it finishes.
 

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -190,6 +190,7 @@ Last reviewed: 2026-05-25.
 
 **Implementations.**
 - PR #33 (Template-version header for drift detection): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Adds `<!-- template-version: SHA -->` and `<!-- generated-at: ISO-timestamp -->` HTML comments to the top of every newly generated skill, plus `{{TEMPLATE_VERSION}}` and `{{GENERATED_AT}}` rows to the Step 4 substitution table. Implements the second bullet of this finding's implications; the periodic regression-check (third bullet) is a separate future change. The drift-detection step in `cdl-dev-loop` Phase 9 is also deferred — it belongs in the cdl-dev-loop repo, not here.
+- PR #35 (Update mode — re-derive existing skills from current template): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Adds an `update` mode to `/create-dev-loop` so the retrofit work that CLAUDE.md's promotion checklist currently mandates can be driven by the skill itself rather than by hand. Complements PR #33's drift detection — #33 detects drift; PR #35 is the remediation channel.
 
 ---
 

--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -23,7 +23,25 @@ ls ~/local-skills/<slug>-dev-loop/ 2>/dev/null
 ls ~/.claude/commands/<slug>-dev-loop.md 2>/dev/null
 ```
 
-If one exists, ask the user whether to overwrite it before continuing.
+**If no skill exists**, set `MODE=fresh` and proceed to Step 2. All subsequent steps run.
+
+**If a skill already exists**, ask the user to choose:
+
+- **update** *(default)* — re-derive the skill from the current template and current repo state, producing a fresh skill file. Set `MODE=update`. Steps 2–5 run; Steps 6 (create GitHub repo) and 7 (record in `my-claude-skills`) are skipped because those artifacts already exist.
+- **overwrite** — re-derive and replace as in fresh generation. Set `MODE=overwrite`. Steps 6–7 still run, idempotently re-asserting the repo and registry entry.
+- **cancel** — exit without changes.
+
+Before proceeding in **update mode**, abort if the local skill directory has uncommitted changes:
+```bash
+cd ~/local-skills/<slug>-dev-loop && git status --porcelain
+```
+If the output is non-empty, stop and ask the user to commit or stash their edits — the update would otherwise overwrite in-progress work.
+
+In **update mode**, after Step 4 completes, show the user a diff between the existing skill file and the freshly generated content *before* overwriting:
+```bash
+diff -u ~/local-skills/<slug>-dev-loop/<slug>-dev-loop.md /tmp/<slug>-dev-loop.new.md
+```
+Get explicit confirmation before replacing the file.
 
 ---
 
@@ -534,6 +552,8 @@ repo-specific choices made (build system, test command, doc sources, reviewer, b
 
 ### 6 — Create a private GitHub repo for the skill
 
+**Skip this step if `MODE=update`** — the repo already exists from the initial generation. (Run only when `MODE=fresh` or `MODE=overwrite`.)
+
 ```bash
 gh repo create <slug>-dev-loop --private --description "Autonomous dev loop skill for {{PROJECT_NAME}}"
 ```
@@ -570,6 +590,8 @@ done
 ---
 
 ### 7 — Record the skill in my-claude-skills
+
+**Skip this step if `MODE=update`** — the entry already exists from the initial generation. (Run only when `MODE=fresh` or `MODE=overwrite`.)
 
 Open `~/my-claude-skills/README.md` and append a new row to the skills table using the GitHub repo created in Step 6:
 


### PR DESCRIPTION
## Summary

When a `<slug>-dev-loop` skill already exists for the current repo, `/create-dev-loop` now offers three modes instead of the previous binary overwrite/cancel:

- **update** *(default)* — re-derive the skill from the current template + current repo state, then show a diff before overwriting. Aborts on uncommitted changes in the local skill directory. Skips Step 6 (create repo) and Step 7 (record in `example-skills-catalog`) since those artifacts already exist.
- **overwrite** — full regeneration, idempotently re-asserting the GitHub repo and `example-skills-catalog` entry.
- **cancel** — exit without changes.

Recommends option A from #16's design notes (re-derive from evidence). Option B (section tagging for surgical updates) is deferred.

This closes the loop with PR #33 (template-version header): #33 *detects* drift via the embedded SHA; this PR is the *remediation* channel — re-run `/create-dev-loop` in update mode to pull in template improvements.

Closes #16

## Test plan

- [x] Step 1's \"skill already exists\" branch now offers update / overwrite / cancel with the recommended default flagged
- [x] Update-mode uncommitted-changes guard: `git status --porcelain` check with explicit abort message
- [x] Pre-overwrite diff (`diff -u` against `/tmp/<slug>-dev-loop.new.md`) and explicit-confirmation requirement
- [x] Step 6 (create GitHub repo) skips in update mode, runs in fresh/overwrite
- [x] Step 7 (record in `example-skills-catalog`) skips in update mode, runs in fresh/overwrite
- [x] Step 5 (register slash command) is idempotent (`ln -sf` + `mkdir -p`) so no conditional needed — confirmed by re-reading the existing block
- [x] README \"Usage\" section documents the three-way prompt
- [x] No new `{{placeholders}}` introduced (`MODE` is a runtime control variable in the instructions, not a generation-time substitution)
- [x] Diff: 29 LOC across 3 files — well under scope ceiling
- [x] Localization verified: \"### 1 — Identify the repository\" at line 11, \"### 6 — Create a private GitHub repo\" at line 553, \"### 7 — Record the skill in example-skills-catalog\" at line 577 (line numbers shifted by edits, but headings are present)
- [x] Per the rule shipped in PR #26, ran `gh issue view 16` and confirmed title/body match
- [x] Per the rule shipped in PR #27, added an Implementations entry under RESEARCH.md §8
- [x] Do-not-auto-merge check (PR #30): modified `README.md`, `RESEARCH.md`, `create-dev-loop.md`; no matches

## Note on option B (section tagging)

#16 recommends starting with option A and evaluating after a few cycles whether human customizations get lost during update. The `<!-- template-version -->` header from PR #33 makes this observable: if a future cycle shows that customized skills lost manual tweaks during update, that's the trigger for revisiting option B.

---

_drafted by Claude on behalf of Daniel Stephenson_
