### PR TITLE
Document Steps 1 and 4 in README, update CLAUDE.md conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ When editing the template:
 - Keep phase numbers stable — generated skills reference them by number in edge-case instructions
 - Every `{{placeholder}}` in the template must have a corresponding row in the Step 4 substitution table
 - Fenced code blocks inside the template are escaped with a leading backslash on the triple-backtick (` \`\`\` `) so they survive being embedded inside the outer markdown code block in `create-dev-loop.md`
+- README "What it does" must enumerate every Step. When a new Step is added or removed, update the README in the same PR. The two are required to stay 1:1.
+- Every generated skill carries `<!-- template-version: <sha> -->` and `<!-- generated-at: <iso8601> -->` HTML comments at the top of the file. Don't drop the convention when adding template features; cosmetic display side-effect is tracked in #36.
 
 ## What belongs here vs. in generated skills
 
@@ -40,6 +42,8 @@ There is no automated test suite. Validate changes by running `/create-dev-loop`
 1. The generated skill file compiles (no unresolved `{{placeholders}}` remain)
 2. The slash command link resolves correctly
 3. The reported summary accurately reflects the target repo
+4. The `<!-- template-version: <sha> -->` and `<!-- generated-at: <iso8601> -->` HTML comments appear at the top of the generated skill, with the SHA matching the create-dev-loop commit you generated from
+5. If the target repo already has a skill, exercise `MODE=update` end-to-end: confirm the abort-on-uncommitted-changes check, the pre-overwrite diff prompt, and that Steps 6–7 are correctly skipped
 
 Use `dpm-dev-loop` or `herald-dev-loop` as reference implementations when evaluating whether a generated skill looks correct.
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,15 @@ When Claude knows your build system, test suite, doc sources, and reviewer patte
 
 ## What it does
 
-Running `/create-dev-loop` in any repo will:
+Running `/create-dev-loop` in any repo runs seven Steps (mapped 1:1 to Steps 1–7 of `create-dev-loop.md`):
 
-1. **Explore** the repository — reads `CLAUDE.md`, `CONTRIBUTING.md`, CI workflows, build files, linter configs, recent PRs, and `CODEOWNERS`
-2. **Compile** a repo-specific profile — build command, test command, branch prefix, reviewer, doc sources, code patterns
-3. **Generate** a ready-to-use `<slug>-dev-loop` skill file at `~/local-skills/<slug>-dev-loop/`
-4. **Register** it as a slash command at `~/.claude/commands/<slug>-dev-loop.md`
-5. **Create** a private GitHub repo (`<slug>-dev-loop`) to serve as the issue tracker for self-audit findings
-6. **Record** the skill in `~/my-claude-skills/README.md` for discoverability
+1. **Identify** the repository — confirms a git toplevel, derives the slug, checks whether a skill already exists and (if so) asks **update** / **overwrite** / **cancel**
+2. **Explore** — reads `CLAUDE.md`, `CONTRIBUTING.md`, CI workflows, build files, linter configs, recent PRs, and `CODEOWNERS` to compile a repo-specific profile (build/test commands, branch prefix, reviewer, doc sources, code patterns)
+3. **Write** the skill file at `~/local-skills/<slug>-dev-loop/<slug>-dev-loop.md` from the template, with a `<!-- template-version: <sha> -->` HTML header so future cycles can detect drift against the template
+4. **Fill in placeholders** — substitutes every `{{PLACEHOLDER}}` and `{{#if FLAG}}` token from Step 2's findings, using the Step 4 substitution table as the contract
+5. **Register** it as a slash command at `~/.claude/commands/<slug>-dev-loop.md`
+6. **Create** a private GitHub repo (`<slug>-dev-loop`) to serve as the issue tracker for self-audit findings (skipped in update mode)
+7. **Record** the skill in `~/my-claude-skills/README.md` for discoverability (skipped in update mode)
 
 The generated skill drives a 10-phase loop: triage → work selection → implementation → PR → review → address comments → doc check → merge → self-audit → repeat.
 


### PR DESCRIPTION
## Summary

Doc-accuracy follow-up from today's audit. Two findings closed:

### README.md — "What it does" lists 6 bullets but the template has 7 Steps

Violated the README-enumerate-every-Step convention that example-h-dev-loop exists to enforce. Step 1 (Identify) was folded into the separate Usage section; Step 4 (Fill in placeholders) was implicit inside the "Generate" bullet. Now both are explicit, and each bullet states its 1:1 mapping to the template Step.

### CLAUDE.md — two missing conventions

- **Skill file conventions** captured only 2 of the 3 structural rules tracked by example-h-dev-loop. Added the README-enumerate rule (third rule) and the `<!-- template-version: <sha> -->` HTML header convention (#22).
- **Testing changes** validation list predated #22 (template-version header) and #35 (update mode). Added two items: verify the HTML header appears with the expected SHA, and exercise \`MODE=update\` end-to-end (abort-on-uncommitted, pre-overwrite diff, Steps 6–7 skipped).

## What didn't change (and why)

- **Hard-coded \"Claude Sonnet 4.6\" co-author trailer in template line 351.** Intentional — that's the runtime model dev-loops execute as, not a stale value. (The current audit ran on Opus 4.7 but Opus is the auditor, not the runtime.)
- **GITHUB_OWNER/REPO combined row in Step 4 table.** Strict-reading nit only; the two tokens behave identically downstream. Defer to a separate PR if you want stricter token accounting.

## Test plan

- [ ] Confirm \"What it does\" now lists exactly 7 bullets matching Steps 1–7 of create-dev-loop.md.
- [ ] Confirm CLAUDE.md \"Skill file conventions\" lists 5 bullets (was 3).
- [ ] Confirm CLAUDE.md \"Testing changes\" lists 5 items (was 3).

Related: example-skills-catalog#6 (CONVENTIONS.md post-retrofit update — picks up the template-version convention there too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_
