### PR TITLE
Add Stephenson-NC license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,34 @@
+# Stephenson Software Non-Commercial License (Based on MIT License)
+
+**Copyright © 2025 Daniel McCoy Stephenson. All rights reserved.**
+
+Stephenson Software is the personal software lab of Daniel McCoy Stephenson and is **not** a legal entity. All rights and ownership of this project are held exclusively by the copyright holder.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to use, copy, modify, merge, publish, and distribute the Software **for non-commercial purposes only**, subject to the following conditions:
+
+## 1. Commercial Use Restriction
+The Software may not be sold, licensed, sublicensed, or otherwise used for commercial advantage by any party other than Daniel McCoy Stephenson, without explicit written permission from the copyright holder.
+
+### Definition of “Commercial Use”
+For the purposes of this license, **Commercial Use** includes (but is not limited to):
+- Any use of the Software in a product, service, or system that is sold, licensed, or otherwise monetized.
+- Use of the Software to provide services, consulting, or solutions for which a fee or compensation is received.
+- Use of the Software in internal business operations, whether or not the software is sold directly.
+- Distribution of the Software (modified or unmodified) bundled with commercial products or services.
+
+## 2. Attribution
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+## 3. Educational and Research Use
+The Software may be freely used for personal learning, academic coursework, research, experimentation, and demonstration purposes, provided it is not used in a commercial product or service.
+
+## 4. Commercial License Availability
+Commercial licensing is available for organizations or individuals who wish to use the Software for commercial purposes.  
+To inquire about commercial licensing, please contact:
+
+**Daniel McCoy Stephenson**  
+[GitHub Profile](https://github.com/dmccoystephenson)  
+**Repository:** https://github.com/Stephenson-Software/stephenson-nc-license
+
+## 5. No Warranty
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,10 @@ Each generated `<slug>-dev-loop` skill encodes:
 ## Research basis
 
 Design decisions for this project are grounded in empirical research on autonomous coding agents — PR-size effects on agent success, self-critique failure modes, context rot in long-horizon runs, and related findings. See [`RESEARCH.md`](RESEARCH.md) for citations and the implications for each phase.
+
+## License
+
+This project is licensed under the **Stephenson Software Non-Commercial License (Stephenson-NC)**.
+
+**License:** Stephenson-NC © 2025 Daniel McCoy Stephenson  
+See [LICENSE.md](./LICENSE.md) for the full legal text, or the canonical repository at <https://github.com/Stephenson-Software/stephenson-nc-license> for details and commercial-licensing inquiries.


### PR DESCRIPTION
## Summary

This project is brought under the **Stephenson Software Non-Commercial License (Stephenson-NC)**.

- The canonical `LICENSE.md` text has been added.
- A `## License` section has been appended to the README, pointing at [`LICENSE.md`](./LICENSE.md) and the canonical [stephenson-nc-license](https://github.com/Stephenson-Software/stephenson-nc-license) repository.

No source behavior is affected; this change is licensing metadata only.

—
drafted by Claude on behalf of Daniel Stephenson