### PR TITLE
Change license to MIT

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,34 +1,21 @@
-# Stephenson Software Non-Commercial License (Based on MIT License)
+MIT License
 
-**Copyright © 2025 Daniel McCoy Stephenson. All rights reserved.**
+Copyright (c) 2025 Daniel McCoy Stephenson
 
-Stephenson Software is the personal software lab of Daniel McCoy Stephenson and is **not** a legal entity. All rights and ownership of this project are held exclusively by the copyright holder.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to use, copy, modify, merge, publish, and distribute the Software **for non-commercial purposes only**, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-## 1. Commercial Use Restriction
-The Software may not be sold, licensed, sublicensed, or otherwise used for commercial advantage by any party other than Daniel McCoy Stephenson, without explicit written permission from the copyright holder.
-
-### Definition of “Commercial Use”
-For the purposes of this license, **Commercial Use** includes (but is not limited to):
-- Any use of the Software in a product, service, or system that is sold, licensed, or otherwise monetized.
-- Use of the Software to provide services, consulting, or solutions for which a fee or compensation is received.
-- Use of the Software in internal business operations, whether or not the software is sold directly.
-- Distribution of the Software (modified or unmodified) bundled with commercial products or services.
-
-## 2. Attribution
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-## 3. Educational and Research Use
-The Software may be freely used for personal learning, academic coursework, research, experimentation, and demonstration purposes, provided it is not used in a commercial product or service.
-
-## 4. Commercial License Availability
-Commercial licensing is available for organizations or individuals who wish to use the Software for commercial purposes.  
-To inquire about commercial licensing, please contact:
-
-**Daniel McCoy Stephenson**  
-[GitHub Profile](https://github.com/dmccoystephenson)  
-**Repository:** https://github.com/Stephenson-Software/stephenson-nc-license
-
-## 5. No Warranty
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Design decisions for this project are grounded in empirical research on autonomo
 
 ## License
 
-This project is licensed under the **Stephenson Software Non-Commercial License (Stephenson-NC)**.
+This project is licensed under the **MIT License**.
 
-**License:** Stephenson-NC © 2025 Daniel McCoy Stephenson  
-See [LICENSE.md](./LICENSE.md) for the full legal text, or the canonical repository at <https://github.com/Stephenson-Software/stephenson-nc-license> for details and commercial-licensing inquiries.
+**License:** MIT © 2025 Daniel McCoy Stephenson  
+See [LICENSE.md](./LICENSE.md) for the full legal text.


### PR DESCRIPTION
## Summary
- Replace the Stephenson Software Non-Commercial License with the standard MIT License in `LICENSE.md`
- Update the README's License section to reflect the switch to MIT

## Test plan
- [x] `grep` confirmed no remaining references to the non-commercial/Stephenson-NC license elsewhere in the repo

---

_drafted by Claude on behalf of Daniel Stephenson_