### PR TITLE
Genericize skill-repo owner and de-link private references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Repo-specific findings (build commands, reviewer names, branch prefixes) belong 
 
 ## Promoting a rule into the template
 
-When you add a new rule to `create-dev-loop.md` because the same lesson keeps showing up in multiple skills' self-audits, **also open retrofit PRs against every existing skill that predates the change.** The template only fixes drift forward; existing skills will silently lag until their next self-audit cycle. See the "Promoting a carry-over into the template" section of [`my-claude-skills/CONVENTIONS.md`](https://github.com/dmccoystephenson/my-claude-skills/blob/main/CONVENTIONS.md) for the checklist.
+When you add a new rule to `create-dev-loop.md` because the same lesson keeps showing up in multiple skills' self-audits, **also open retrofit PRs against every existing skill that predates the change.** The template only fixes drift forward; existing skills will silently lag until their next self-audit cycle. (The project maintainer tracks this checklist in a private `my-claude-skills/CONVENTIONS.md` reference; external contributors without access should instead note in the PR description which existing skills likely need a retrofit pass, so a maintainer can follow up.)
 
 ## Grounding work in research
 
@@ -45,7 +45,7 @@ There is no automated test suite. Validate changes by running `/create-dev-loop`
 4. The `<!-- template-version: <sha> -->` and `<!-- generated-at: <iso8601> -->` HTML comments appear at the top of the generated skill, with the SHA matching the create-dev-loop commit you generated from
 5. If the target repo already has a skill, exercise `MODE=update` end-to-end: confirm the abort-on-uncommitted-changes check, the pre-overwrite diff prompt, and that Steps 6–7 are correctly skipped
 
-Use `dpm-dev-loop` or `herald-dev-loop` as reference implementations when evaluating whether a generated skill looks correct.
+The maintainer validates against private reference implementations (`dpm-dev-loop`, `herald-dev-loop`); external contributors without access should validate by running `/create-dev-loop` against any real repository they maintain and manually checking the five items above.
 
 ## Commit and PR conventions
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,6 @@ Each generated `<slug>-dev-loop` skill encodes:
 - **Code patterns** — conventions from `CLAUDE.md` encoded directly into Phase 3
 - **Do-not-auto-merge paths** — files that require human review before merge (e.g. `plugin.yml`, `pom.xml`), in addition to universal entries like `.github/workflows/*`
 
-## Related skills
-
-- `dpm-dev-loop` — the reference implementation this skill is modeled on
-- `herald-dev-loop` — another example of a repo-specific generated loop
-
 ## Research basis
 
 Design decisions for this project are grounded in empirical research on autonomous coding agents — PR-size effects on agent success, self-critique failure modes, context rot in long-horizon runs, and related findings. See [`RESEARCH.md`](RESEARCH.md) for citations and the implications for each phase.

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -193,7 +193,7 @@ Last reviewed: 2026-07-25.
 **Implication for create-dev-loop.**
 - The existing retrofit checklist in `CLAUDE.md` (promote rule to template *and* retrofit existing child skills) is empirically justified — forward-only template fixes leave existing skills silently lagging.
 - Consider adding a "skill version + tested-against-model" header to generated skills, so a future self-audit can distinguish drift from a fresh bug.
-- Consider periodic regression checks: dry-run the generated skill against a known-good fixture repo and compare output to a recorded baseline. The `dpm-dev-loop` / `herald-dev-loop` references could serve as fixtures.
+- Consider periodic regression checks: dry-run the generated skill against a known-good fixture repo and compare output to a recorded baseline. The maintainer's private `dpm-dev-loop` / `herald-dev-loop` repos serve as fixtures internally; external contributors can substitute any repo they maintain.
 
 **Implementations.**
 - PR #33 (Template-version header for drift detection): shipped 2026-05-25. Observed effect: pending — needs N cycles of data. Adds `<!-- template-version: SHA -->` and `<!-- generated-at: ISO-timestamp -->` HTML comments to the top of every newly generated skill, plus `{{TEMPLATE_VERSION}}` and `{{GENERATED_AT}}` rows to the Step 4 substitution table. Implements the second bullet of this finding's implications; the periodic regression-check (third bullet) is a separate future change. The drift-detection step in `cdl-dev-loop` Phase 9 is also deferred — it belongs in the cdl-dev-loop repo, not here.

--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -118,7 +118,7 @@ Autonomous iterative development loop for {{PROJECT_NAME}}.
 
 **Working directory:** {{REPO_ROOT}} (resolved at runtime — see Phase 1; do not assume this literal path exists)
 **Project repo:** {{GITHUB_OWNER}}/{{GITHUB_REPO}}
-**Skill repo:** dmccoystephenson/<slug>-dev-loop (issues for self-audit findings go here)
+**Skill repo:** {{SKILL_REPO_OWNER}}/<slug>-dev-loop (issues for self-audit findings go here)
 {{#if CLAUDE_MD}}**Project guidance:** read `CLAUDE.md` at the start of each cycle if context is cold.{{/if}}
 
 ---
@@ -472,7 +472,7 @@ gh issue close <number> --comment "Resolved in PR #<n>."
 
 1. **Check for duplicates** before filing:
    \`\`\`bash
-   gh issue list --repo dmccoystephenson/<slug>-dev-loop --state open
+   gh issue list --repo {{SKILL_REPO_OWNER}}/<slug>-dev-loop --state open
    \`\`\`
 
 2. **Run the self-audit rubric.** For each item, mark PASS / FAIL / "no signal this cycle" with a one-line justification grounded in the cycle's actual events:
@@ -487,7 +487,7 @@ gh issue close <number> --comment "Resolved in PR #<n>."
 
 3. **For each FAIL item not already tracked, file a labeled issue** so triage knows where the gap belongs:
    \`\`\`bash
-   gh issue create --repo dmccoystephenson/<slug>-dev-loop \
+   gh issue create --repo {{SKILL_REPO_OWNER}}/<slug>-dev-loop \
      --title "<short description of the gap>" \
      --body "<what was ambiguous or missing, and suggested instruction text>" \
      --label <one-of: template-rule | repo-specific | edge-case | research-gap | process>
@@ -540,7 +540,7 @@ git push origin --delete {{BRANCH_PREFIX}}/<name>
 **Two issues conflict mid-implementation:** finish the further-along one; file a note on the other.
 **Cycle exceeds abort budget:** if the cycle's tool calls exceed ~500 or accumulated context exceeds ~200k tokens without converging, abort rather than push through. The half-life model (RESEARCH.md §4) predicts persistence past a budget is strictly worse than restart with fresh context. Steps:
 1. Mark the in-flight PR `Draft` (`gh pr ready --undo <number>`) or, if no PR is open, push the branch with a `WIP:` commit so work isn't lost.
-2. File a gap issue on `dmccoystephenson/<slug>-dev-loop` with title `Abort budget exceeded on <branch>` and body containing:
+2. File a gap issue on `{{SKILL_REPO_OWNER}}/<slug>-dev-loop` with title `Abort budget exceeded on <branch>` and body containing:
    - **Issues in scope:** the `#N`s the cycle was trying to close
    - **Files modified so far:** path list
    - **Where convergence stalled:** the last phase reached and what was blocking it
@@ -558,10 +558,11 @@ Use findings from Step 2 to substitute each `{{placeholder}}`. The table below c
 | Placeholder | How to determine it |
 |-------------|---------------------|
 | `PROJECT_NAME` | Directory name or `name` field in build file |
-| `IDENTITY` | One sentence completing "the kind of skill that ___". Draft it from the repo's actual posture: read `CLAUDE.md`, `CONTRIBUTING.md`, and 2-3 recent PRs to infer what *this* skill is optimizing for in *this* repo. The identity must **name what the skill actively rejects** (e.g. "never lets the four sources of truth drift"), not just what it pursues. See the Identity statements section of [my-claude-skills/CONVENTIONS.md](https://github.com/dmccoystephenson/my-claude-skills/blob/main/CONVENTIONS.md). |
+| `IDENTITY` | One sentence completing "the kind of skill that ___". Draft it from the repo's actual posture: read `CLAUDE.md`, `CONTRIBUTING.md`, and 2-3 recent PRs to infer what *this* skill is optimizing for in *this* repo. The identity must **name what the skill actively rejects** (e.g. "never lets the four sources of truth drift"), not just what it pursues. |
 | `REPO_ROOT` | Output of `git rev-parse --show-toplevel`. Used as the *configured* fallback path in the Phase 1 resolution block, not as a hardcoded `cd` target. |
 | `REPO_ENV_VAR` | Name of the per-repo override env var the Phase 1 resolver checks first, derived from the repo slug: uppercase, non-alphanumerics→`_`, suffix `_DIR` (e.g. `dpm` → `DPM_DIR`, `medieval-factions` → `MEDIEVAL_FACTIONS_DIR`). Substituted bare (no braces) into `${VAR}` in the resolver. |
 | `GITHUB_OWNER/REPO` | `gh repo view --json nameWithOwner -q .nameWithOwner` |
+| `SKILL_REPO_OWNER` | `gh api user -q .login` — the authenticated GitHub account that ran `/create-dev-loop`, i.e. the owner of the skill-tracker repo created in Step 6. Not necessarily the same as `GITHUB_OWNER` when the target project lives under an org. |
 | `DEFAULT_BRANCH` | `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` |
 | `BRANCH_PREFIX` | From CONTRIBUTING.md, or `feature` if not specified |
 | `COMPILE_CMD` | Fastest command that catches syntax/import errors without running tests. For Maven: `MVN=$([ -f ./mvnw ] && echo ./mvnw \|\| echo mvn) && $MVN compile`. **If the repo has no build system** (docs-only, config-only, single-template repos), substitute the cheapest mechanical consistency check that would actually catch breakage — e.g. a `grep` for unresolved placeholders, `jq -e . <config>`, a YAML/schema lint. If no such check exists, substitute a shell comment naming what gates correctness instead (e.g. `# no build system — see the validation steps below`) so the fence stays valid bash. |
@@ -658,10 +659,10 @@ done
 
 **Skip this step if `MODE=update`** — the entry already exists from the initial generation. (Run only when `MODE=fresh` or `MODE=overwrite`.)
 
-Open `~/my-claude-skills/README.md` and append a new row to the skills table using the GitHub repo created in Step 6:
+Open `~/my-claude-skills/README.md` and append a new row to the skills table using the GitHub repo created in Step 6 (`OWNER=$(gh api user -q .login)`, same as Step 6):
 
 ```
-| <slug>-dev-loop | `/<slug>-dev-loop` | [dmccoystephenson/<slug>-dev-loop](https://github.com/dmccoystephenson/<slug>-dev-loop) | Autonomous dev loop for {{PROJECT_NAME}} |
+| <slug>-dev-loop | `/<slug>-dev-loop` | [$OWNER/<slug>-dev-loop](https://github.com/$OWNER/<slug>-dev-loop) | Autonomous dev loop for {{PROJECT_NAME}} |
 ```
 
 Then commit and push:


### PR DESCRIPTION
## Summary
Part of prep to open-source this repo (follow-up to #59, the MIT license switch). Fixes two blockers for external usage:

- **Hardcoded username:** the generated `<slug>-dev-loop` skill previously wrote `dmccoystephenson/<slug>-dev-loop` literally in four places (skill-repo header, both self-audit `gh issue` commands, and the abort-budget gap-issue instruction). Anyone else running `/create-dev-loop` would generate a skill that tries to file issues against *the maintainer's* account instead of their own. Replaced with a new `{{SKILL_REPO_OWNER}}` placeholder derived from `gh api user -q .login` at generation time, with a substitution-table row. Step 7's own instructions (not template output) now use the same `$OWNER` pattern Step 6 already established, instead of a literal username.
- **Private reference implementations:** `README.md`, `CLAUDE.md`, and `RESEARCH.md` pointed contributors at `example-l-dev-loop`, `example-q-dev-loop`, and `example-skills-catalog/CONVENTIONS.md` as if they were inspectable — all three are private repos used for personal validation. Removed the dead "Related skills" section from the README, and reworded the CLAUDE.md/RESEARCH.md mentions to name them as private maintainer fixtures with a fallback instruction for contributors who don't have access (validate against any repo you maintain; note in the PR description which skills may need a retrofit pass).

## Test plan
- [x] `grep -rn dmccoystephenson create-dev-loop.md README.md RESEARCH.md CLAUDE.md` returns no matches
- [x] README "What it does" Step list still 1:1 with `create-dev-loop.md`'s seven Steps (per CLAUDE.md's doc-sync rule)
- [x] New `{{SKILL_REPO_OWNER}}` placeholder has a substitution-table row, consistent with the other `{{placeholder}}` rows
- [ ] Not run end-to-end against a real repo (no automated test suite for this project; per CLAUDE.md, real validation is running `/create-dev-loop` live)

---

_drafted by Claude on behalf of Daniel Stephenson_