### PR TITLE
Add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,115 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our
+  mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political
+  attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our
+standards of acceptable behavior and will take appropriate and fair
+corrective action in response to any behavior that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that
+are not aligned with this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces for this project
+(issues, pull requests, discussions), and also applies when an individual is
+officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer via the project's
+[GitHub profile](https://github.com/dmccoystephenson). All complaints will
+be reviewed and investigated promptly and fairly.
+
+All maintainers are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Maintainers will follow these Community Impact Guidelines in determining the
+consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning, providing clarity around the
+nature of the violation and an explanation of why the behavior was
+inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to create-dev-loop
+
+Thanks for considering a contribution. This repo is small on purpose — the
+entire product is [`create-dev-loop.md`](create-dev-loop.md), a single skill
+file that generates tailored dev-loop skills for other repos. Most changes
+touch that one file (or its supporting docs), and the bar for correctness is
+that the template stays internally consistent.
+
+## Before you start
+
+- **Small fixes** (typos, broken links, a missing substitution-table row) —
+  just open a PR.
+- **Anything that changes behavior** (a new Step, a new placeholder, a
+  changed Phase in the generated skill) — open an issue first describing the
+  problem and your proposed approach. This repo's design decisions are
+  expected to be grounded in empirical research rather than intuition; see
+  [`RESEARCH.md`](RESEARCH.md) and the "Grounding work in research" section
+  of [`CLAUDE.md`](CLAUDE.md) before proposing a change to the template or a
+  phase definition.
+
+## Project conventions
+
+The canonical rules for this repo live in [`CLAUDE.md`](CLAUDE.md) — it's
+written for an AI coding agent, but the conventions apply equally to human
+contributors:
+
+- Keep phase numbers stable in the generated-skill template; generated
+  skills reference them by number.
+- Every `{{placeholder}}` in the template needs a corresponding row in the
+  Step 4 substitution table.
+- `README.md`'s "What it does" list must stay 1:1 with the Steps in
+  `create-dev-loop.md` — update both in the same PR.
+- If your change implements or contradicts a finding in `RESEARCH.md`,
+  update that file in the same PR (see its "How to use this document"
+  section for the entry format).
+
+## Making a change
+
+1. Fork the repo and create a branch: `feature/<short-name>` for new
+   capability, `fix/<short-name>` for corrections.
+2. Edit `create-dev-loop.md` (and `README.md` / `RESEARCH.md` / `CLAUDE.md`
+   as needed — see "Project conventions" above).
+3. Validate your change. There is no automated test suite; the real test is
+   running `/create-dev-loop` against a real repository and confirming:
+   - the generated skill file compiles (no unresolved `{{placeholders}}`
+     remain)
+   - the slash command link resolves correctly
+   - the reported summary accurately reflects the target repo
+   - the `<!-- template-version -->` / `<!-- generated-at -->` HTML comments
+     appear correctly
+   - if you touched update-mode behavior, exercise `MODE=update` end-to-end
+
+   The maintainer validates against private reference repos for this step;
+   if you don't have a suitable repo handy, any real project you maintain
+   works as a fixture.
+4. Commit using imperative mood, no trailing period (e.g. `Add SKILL_REPO_OWNER placeholder`).
+5. Open a PR referencing any related issue with `Closes #N`. Describe what
+   you tested it against.
+
+## Retrofitting existing generated skills
+
+If your change fixes a lesson that showed up in multiple skills' self-audits
+(per `CLAUDE.md`'s "Promoting a rule into the template" section), please
+note in your PR description which existing `<slug>-dev-loop` skills likely
+need a retrofit pass, even if you can't open those PRs yourself.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under
+the project's [MIT License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Each generated `<slug>-dev-loop` skill encodes:
 
 Design decisions for this project are grounded in empirical research on autonomous coding agents — PR-size effects on agent success, self-critique failure modes, context rot in long-horizon runs, and related findings. See [`RESEARCH.md`](RESEARCH.md) for citations and the implications for each phase.
 
+## Contributing
+
+Contributions are welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the workflow and this project's conventions, and [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) for community standards.
+
 ## License
 
 This project is licensed under the **MIT License**.


### PR DESCRIPTION
## Summary
Continues the open-source prep started in #59 (MIT license) and #60 (de-hardcode owner references).

- **`CONTRIBUTING.md`** — points contributors at `CLAUDE.md` as the canonical rules doc, explains when to open an issue first vs. just PR a fix, restates this repo's specific conventions (branch prefixes, doc-sync requirement between `README.md`/`create-dev-loop.md`, research-grounding requirement, and how to validate a change without an automated test suite).
- **`CODE_OF_CONDUCT.md`** — standard Contributor Covenant v2.1, with the enforcement contact pointed at the maintainer's GitHub profile (consistent with how `LICENSE.md` already routes inquiries there rather than a raw email).
- Linked both from a new "Contributing" section in `README.md`.

## Test plan
- [x] Both new files render as valid Markdown (checked by eye)
- [x] README links resolve to the new files in the same PR
- N/A — no automated test suite for this project (docs-only change)

---

_drafted by Claude on behalf of Daniel Stephenson_