### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Something in create-dev-loop.md produces a wrong or broken generated skill
+title: ""
+labels: bug
+assignees: ""
+---
+
+**What went wrong**
+A clear description of the incorrect behavior.
+
+**Which Step(s) of `create-dev-loop.md`**
+e.g. Step 2 (explore), Step 3 (write skill), Step 4 (fill placeholders)...
+
+**Repo you generated against**
+Language/build system, and anything about the repo's structure that might be
+relevant (monorepo, no CI, no test suite, etc.). No need to link a private
+repo — a description is enough.
+
+**Expected vs. actual**
+What the generated skill should have contained, vs. what it actually
+contained (paste the relevant excerpt, e.g. an unresolved `{{placeholder}}`
+or a wrong command).
+
+**Additional context**
+Anything else that would help track this down.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose new capability for create-dev-loop.md (a new Step, placeholder, or Phase behavior)
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**What's missing or limited today**
+Describe the gap in what `/create-dev-loop` currently produces or supports.
+
+**Proposed change**
+What you'd want the template to do instead. If this changes a Step count or
+a Phase in the generated skill, say so explicitly — those need to stay in
+sync with `README.md` per `CLAUDE.md`'s doc-sync rule.
+
+**Research grounding**
+Per `CLAUDE.md`, changes to the template or a phase definition should be
+grounded in empirical research rather than intuition. Cite a relevant
+`RESEARCH.md` finding if one applies, or say explicitly that none does yet.
+
+**Alternatives considered**
+Any other approaches you thought about and why you didn't propose them.

--- a/.github/ISSUE_TEMPLATE/template_rule.md
+++ b/.github/ISSUE_TEMPLATE/template_rule.md
@@ -1,0 +1,26 @@
+---
+name: Promote a rule into the template
+about: A lesson kept showing up across generated <slug>-dev-loop skills' self-audits and belongs in create-dev-loop.md
+title: ""
+labels: template-rule
+assignees: ""
+---
+
+**Which skill(s) surfaced this**
+Name the generated `<slug>-dev-loop` skill(s) where this gap showed up in a
+self-audit (Phase 9). No need to link a private repo — a description of the
+skill/project is enough.
+
+**What was ambiguous or missing**
+What the current template (or a specific Step/Phase) doesn't cover, or
+covers incorrectly.
+
+**Suggested instruction text**
+Draft wording for the fix — a new/changed line in `create-dev-loop.md`, a
+new substitution-table row, a new Edge case entry, etc.
+
+**Retrofit scope**
+Per `CLAUDE.md`'s "Promoting a rule into the template" section: once this
+rule lands in `create-dev-loop.md`, existing `<slug>-dev-loop` skills that
+predate the change need a retrofit PR too. List any you know need one, even
+if you can't open those PRs yourself.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What changed and why. Reference the issue with "Closes #N" if applicable. -->
+
+## Research grounding
+
+<!--
+Per CLAUDE.md: changes to create-dev-loop.md, the generated template, or a
+phase definition should cite the relevant RESEARCH.md finding(s), or state
+explicitly that none applies. Delete this section if your change doesn't
+touch the template (e.g. docs-only).
+-->
+
+## Doc sync check
+
+<!-- Delete any line that doesn't apply to this PR. -->
+
+- [ ] `README.md`'s "What it does" Step list still matches `create-dev-loop.md`'s Steps 1:1
+- [ ] Every `{{placeholder}}` added or changed has a corresponding Step 4 substitution-table row
+- [ ] `RESEARCH.md` updated (new finding, or an **Implementations** entry if this ships a finding)
+
+## Test plan
+
+<!--
+There is no automated test suite for this repo. Describe how you validated
+the change — see CLAUDE.md's "Testing changes" section (running
+/create-dev-loop against a real repo and checking the generated skill
+compiles, MODE=update behaves correctly, etc.).
+-->


### PR DESCRIPTION
## Summary
Continues open-source prep (#59, #60, #63). Adds `.github/ISSUE_TEMPLATE/` and a PR template.

Looked at this repo's actual label usage first (`gh label list` + recent issues) rather than guessing: alongside the GitHub defaults, `dmccoystephenson/create-dev-loop` has five custom labels (`template-rule`, `edge-case`, `repo-specific`, `research-gap`, `process`) from the self-audit taxonomy in `create-dev-loop.md`, and the large majority of this repo's own recent issues (#40-51 etc.) are `template-rule` issues — the "a lesson kept showing up across generated skills, promote it into the template" workflow `CLAUDE.md` describes. So the templates are:

- `bug_report.md` — wrong/broken generated-skill output, labeled `bug`
- `feature_request.md` — new template capability, labeled `enhancement`, prompts for `RESEARCH.md` grounding per `CLAUDE.md`
- `template_rule.md` — matches the repo's dominant actual workflow, labeled `template-rule`, prompts for which skill(s) surfaced the gap and which existing skills need a retrofit PR
- `config.yml` — `blank_issues_enabled: true` (no contact_links; Discussions isn't enabled on this repo)
- `PULL_REQUEST_TEMPLATE.md` — Summary/Research grounding/Doc sync checklist/Test plan, mirroring the checks `CONTRIBUTING.md` and `CLAUDE.md` already ask for, so new contributors see them at PR-creation time instead of discovering them after the fact

## Test plan
- N/A — docs/templates only, no automated test suite for this repo
- [x] Confirmed via `gh repo view --json hasDiscussionsEnabled` that Discussions is off, so `config.yml` doesn't link a dead contact

---

_drafted by Claude on behalf of Daniel Stephenson_