### PR TITLE
Add CI: automated doc-consistency checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  doc-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Check doc consistency
+        run: python3 scripts/check_docs.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ When proposing a change to `create-dev-loop.md`, the generated template, or a ph
 
 ## Testing changes
 
-There is no automated test suite. Validate changes by running `/create-dev-loop` against a real repo and confirming:
+CI (`.github/workflows/ci.yml`) runs `scripts/check_docs.py`, which mechanically enforces two of the rules above — every `{{placeholder}}` in the template has a Step 4 substitution-table row, and README's "What it does" list stays 1:1 with the Steps — plus checks that relative links between the repo's own docs resolve. It catches doc-drift, not behavior; there is no automated test of what `/create-dev-loop` actually generates. Validate behavioral changes by running `/create-dev-loop` against a real repo and confirming:
 1. The generated skill file compiles (no unresolved `{{placeholders}}` remain)
 2. The slash command link resolves correctly
 3. The reported summary accurately reflects the target repo

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # create-dev-loop
 
+[![CI](https://github.com/dmccoystephenson/create-dev-loop/actions/workflows/ci.yml/badge.svg)](https://github.com/dmccoystephenson/create-dev-loop/actions/workflows/ci.yml)
+
 A Claude Code skill that generates a **tailored autonomous dev loop** for any git repository — one slash command away from continuous, repo-aware development.
 
 ## Why a tailored dev loop?

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Mechanically enforce the doc-consistency invariants CLAUDE.md documents by hand:
+
+1. Every {{placeholder}} used in the create-dev-loop.md template has a row in
+   the Step 4 substitution table.
+2. README.md's "What it does" list stays 1:1 with create-dev-loop.md's Steps.
+3. Relative links between the repo's own docs resolve to real files.
+
+No third-party dependencies; runs on any Python 3.
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_FILE = REPO_ROOT / "create-dev-loop.md"
+README_FILE = REPO_ROOT / "README.md"
+
+# Compound substitution-table rows that cover more than one {{placeholder}}.
+COMPOUND_ROWS = {
+    "GITHUB_OWNER/REPO": {"GITHUB_OWNER", "GITHUB_REPO"},
+}
+
+errors = []
+
+
+def extract_template_body(text: str) -> str:
+    lines = text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == "```markdown":
+            start = i
+            break
+    if start is None:
+        errors.append("Could not find the ```markdown fence that opens the generated-skill template.")
+        return ""
+    end = None
+    for i in range(start + 1, len(lines)):
+        if lines[i] == "```":
+            end = i
+            break
+    if end is None:
+        errors.append("Could not find the closing ``` fence for the generated-skill template.")
+        return ""
+    return "\n".join(lines[start + 1:end])
+
+
+def check_placeholders(text: str, template_body: str) -> None:
+    used = set()
+    for raw in re.findall(r"\{\{([^}]*)\}\}", template_body):
+        raw = raw.strip()
+        if raw.startswith("#if "):
+            used.add(raw[len("#if "):].strip())
+        elif raw == "/if":
+            continue
+        else:
+            used.add(raw)
+
+    table_start = text.find("### 4 — Fill in the placeholders")
+    if table_start == -1:
+        errors.append("Could not find the '### 4 — Fill in the placeholders' section.")
+        return
+    table_section = text[table_start:table_start + 8000]
+
+    declared = set()
+    for line in table_section.splitlines():
+        m = re.match(r"^\|\s*`([^`]+)`\s*\|", line)
+        if not m:
+            continue
+        name = m.group(1)
+        declared |= COMPOUND_ROWS.get(name, {name})
+
+    missing = sorted(used - declared)
+    if missing:
+        errors.append(
+            "Placeholder(s) used in the template but missing a Step 4 substitution-table row: "
+            + ", ".join(f"{{{{{p}}}}}" for p in missing)
+        )
+
+
+def check_readme_steps_sync(cdl_text: str, readme_text: str) -> None:
+    step_numbers = sorted(int(n) for n in re.findall(r"^### (\d+) — ", cdl_text, re.MULTILINE))
+
+    what_it_does = re.search(r"## What it does\n(.*?)(?:\n## |\Z)", readme_text, re.DOTALL)
+    if not what_it_does:
+        errors.append("README.md has no '## What it does' section to compare against create-dev-loop.md's Steps.")
+        return
+    readme_numbers = sorted(int(n) for n in re.findall(r"^(\d+)\. \*\*", what_it_does.group(1), re.MULTILINE))
+
+    if step_numbers != readme_numbers:
+        errors.append(
+            f"README.md 'What it does' list ({readme_numbers}) is out of sync with "
+            f"create-dev-loop.md's Steps ({step_numbers}). CLAUDE.md requires these to stay 1:1."
+        )
+
+
+def check_local_links() -> None:
+    link_re = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+    for doc in REPO_ROOT.glob("*.md"):
+        text = doc.read_text(encoding="utf-8")
+        for target in link_re.findall(text):
+            if target.startswith(("http://", "https://", "mailto:")):
+                continue
+            path_part = target.split("#", 1)[0]
+            if not path_part:
+                continue
+            resolved = (REPO_ROOT / path_part).resolve()
+            if not resolved.exists():
+                errors.append(f"{doc.name}: broken relative link -> {target}")
+
+
+def main() -> int:
+    cdl_text = TEMPLATE_FILE.read_text(encoding="utf-8")
+    readme_text = README_FILE.read_text(encoding="utf-8")
+
+    template_body = extract_template_body(cdl_text)
+    if template_body:
+        check_placeholders(cdl_text, template_body)
+    check_readme_steps_sync(cdl_text, readme_text)
+    check_local_links()
+
+    if errors:
+        print("Doc consistency check FAILED:\n")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    print("Doc consistency check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Continues open-source prep (#59, #60, #63, #64). This repo has no automated test suite for behavior — validating what `/create-dev-loop` actually generates still requires running it against a real repo (CLAUDE.md's "Testing changes" section), and that's not something CI can do without an LLM in the loop.

But CLAUDE.md documents two hard invariants that were previously only checked by eye:
- Every `{{placeholder}}` used in the generated-skill template needs a corresponding row in the Step 4 substitution table
- README.md's "What it does" list must stay 1:1 with `create-dev-loop.md`'s Steps

`scripts/check_docs.py` (stdlib-only, no dependencies) enforces both mechanically by parsing the template out of its fenced code block and diffing it against the substitution table and the README list, plus checks that relative links between the repo's own `.md` files resolve to real files (the kind of thing #60 fixed by hand). Wired up via `.github/workflows/ci.yml` on push/PR to `main`. Added a CI badge to the README.

## Test plan
- [x] `python3 scripts/check_docs.py` passes on the current tree
- [x] Manually verified each check fires on a real regression, then reverted:
  - removed a substitution-table row → caught the missing placeholder
  - renumbered a Step heading out of sync with the README list → caught the mismatch
  - added a link to a nonexistent file → caught the broken link

---

_drafted by Claude on behalf of Daniel Stephenson_