### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python (scripts/check_docs.py)
+__pycache__/
+*.pyc
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Editors
+.vscode/
+.idea/
+*.swp
+*.swo


### PR DESCRIPTION
## Summary
Final piece of the standard-scaffolding pass from the open-source prep (#59, #60, #63, #64, #65). Covers the artifacts most likely for a contributor working in this repo: Python cache files (from `scripts/check_docs.py`), OS cruft, and common editor directories.

## Test plan
- [x] `python3 scripts/check_docs.py` still passes

---

_drafted by Claude on behalf of Daniel Stephenson_