### PR TITLE
Add SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Design decisions for this project are grounded in empirical research on autonomo
 
 Contributions are welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the workflow and this project's conventions, and [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) for community standards.
 
+## Security
+
+`/create-dev-loop` reads and acts on content from whatever repo you run it in. See [`SECURITY.md`](SECURITY.md) for the trust model and how to report a vulnerability.
+
 ## License
 
 This project is licensed under the **MIT License**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you find a security issue in `create-dev-loop.md` itself (e.g. an
+instruction that could be used to make the generated skill take unsafe
+actions), please report it privately via the maintainer's
+[GitHub profile](https://github.com/dmccoystephenson) rather than opening a
+public issue. Include:
+
+- The Step or Phase involved
+- What unsafe behavior it enables
+- A minimal repro (a description of the target-repo content that triggers it
+  is enough — no need to share a private repo)
+
+You should expect an initial response within a few days.
+
+## Trust model
+
+`/create-dev-loop` reads files from whatever repository you run it in —
+`CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, CI configs, `CODEOWNERS`, and
+recent PR descriptions — and uses their content to decide what the
+generated skill does: its stated identity, its self-review rubric, its
+reviewer, its branch conventions, and so on (Step 2 of
+`create-dev-loop.md`).
+
+This means the target repo's content directly shapes an autonomous
+skill that will later create branches, open PRs, and push commits with
+`gh`/`git`. **Only run `/create-dev-loop` against repositories you trust.**
+A repository crafted to manipulate the generation process (e.g. planted
+instructions in `CLAUDE.md` aimed at the agent rather than at humans) could
+cause the generated skill to encode unsafe or unintended behavior. This is
+the same class of risk as running any AI coding agent against untrusted
+input — treat it accordingly.
+
+This policy covers `create-dev-loop.md` and the generation process it
+describes. It does not cover the behavior of skills it generates once
+you've reviewed and started using them — those are regular Claude Code
+skills subject to the same scrutiny you'd give any other.


### PR DESCRIPTION
## Summary
Follow-up to the open-source prep audit (#59, #60, #63, #64, #65, #66).

- Reporting path: private report via the maintainer's GitHub profile (GitHub Security Advisories / vulnerability alerts aren't enabled on this repo, so that route is not claimed).
- Trust model: Step 2 of `create-dev-loop.md` reads `CLAUDE.md`/`CONTRIBUTING.md`/`README.md`/`CODEOWNERS`/recent PRs from whatever repo you run `/create-dev-loop` in, and that content shapes what the generated skill does — its stated identity, rubric, reviewer, branch conventions — before it goes on to `gh`/`git` autonomously. Documents that this is a trust-the-target-repo model, same class of risk as running any agent against untrusted input, and that the policy covers the generation process itself, not downstream generated skills' behavior.
- Linked from a new "Security" section in `README.md`.

## Test plan
- [x] `python3 scripts/check_docs.py` passes (new README link resolves, no placeholder/step drift)

---

_drafted by Claude on behalf of Daniel Stephenson_