### PR TITLE
Make example-skills-catalog catalog recording optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Running `/create-dev-loop` in any repo runs seven Steps (mapped 1:1 to Steps 1�
 4. **Fill in placeholders** — substitutes every `{{PLACEHOLDER}}` and `{{#if FLAG}}` token from Step 2's findings, using the Step 4 substitution table as the contract
 5. **Register** it as a slash command at `~/.claude/commands/<slug>-dev-loop.md`
 6. **Create** a private GitHub repo (`<slug>-dev-loop`) to serve as the issue tracker for self-audit findings, and seed it with the five gap-issue labels Phase 9 files against (skipped in update mode)
-7. **Record** the skill in `~/my-claude-skills/README.md` for discoverability (skipped in update mode)
+7. **Record** the skill in `~/my-claude-skills/README.md` for discoverability, if that optional personal catalog repo exists (skipped in update mode, and skipped silently if the catalog isn't present)
 
 The generated skill drives a 10-phase loop: triage → work selection → implementation → PR → review → address comments → doc check → merge → self-audit → repeat.
 
@@ -41,7 +41,7 @@ The generated skill drives a 10-phase loop: triage → work selection → implem
 
 Run this from inside any git repository. If a skill already exists for the repo, you'll be asked to choose:
 
-- **update** *(default)* — re-derive the skill from the current template and current repo state, then show a diff before overwriting. Use this to pull in template improvements without re-creating the GitHub repo or `my-claude-skills` entry. Aborts if the local skill directory has uncommitted changes.
+- **update** *(default)* — re-derive the skill from the current template and current repo state, then show a diff before overwriting. Use this to pull in template improvements without re-creating the GitHub repo or catalog entry. Aborts if the local skill directory has uncommitted changes.
 - **overwrite** — full regeneration, idempotently re-asserting the repo and registry entry.
 - **cancel** — exit without changes.
 

--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -655,11 +655,19 @@ done
 
 ---
 
-### 7 — Record the skill in my-claude-skills
+### 7 — Record the skill in a personal catalog (optional)
 
-**Skip this step if `MODE=update`** — the entry already exists from the initial generation. (Run only when `MODE=fresh` or `MODE=overwrite`.)
+**Skip this step if `MODE=update`** — the entry already exists from the initial generation, if one was made. (Run only when `MODE=fresh` or `MODE=overwrite`.)
 
-Open `~/my-claude-skills/README.md` and append a new row to the skills table using the GitHub repo created in Step 6 (`OWNER=$(gh api user -q .login)`, same as Step 6):
+`~/my-claude-skills` is an optional personal catalog convention, not something every user has. Check first:
+
+```bash
+[ -d ~/my-claude-skills/.git ] && echo present || echo absent
+```
+
+**If absent**, skip this step silently — it is not required for the generated skill to work (Step 5 already registered the slash command). Do not create the directory or repo on the user's behalf.
+
+**If present**, open `~/my-claude-skills/README.md` and append a new row to the skills table using the GitHub repo created in Step 6 (`OWNER=$(gh api user -q .login)`, same as Step 6):
 
 ```
 | <slug>-dev-loop | `/<slug>-dev-loop` | [$OWNER/<slug>-dev-loop](https://github.com/$OWNER/<slug>-dev-loop) | Autonomous dev loop for {{PROJECT_NAME}} |


### PR DESCRIPTION
## Summary
- Step 7 assumed every user maintains a `~/example-skills-catalog` catalog repo and unconditionally `cd`s into it — for anyone without that repo, this would hard-fail generation right after Steps 1-6 already did real work (GitHub repo created, labels seeded, slash command registered).
- Now checks `[ -d ~/example-skills-catalog/.git ]` first. If present, records the skill as before. If absent, skips silently — Step 5 already registered the slash command, so the generated skill is fully functional without a catalog entry.
- Updated README's Step 7 description and the update-mode bullet to reflect the optionality.

## Why
Flagged during OSS-readiness review: `~/local-skills/` (Steps 1/3/5) already degrades gracefully via `mkdir -p`, but `~/example-skills-catalog/` (Step 7) did not. This was the one remaining hard external-contributor blocker from the OSS-prep audit.

## Test plan
- [x] `python3 scripts/check_docs.py` passes
- [x] No new `{{placeholder}}` introduced
- [x] Traced Step 7 logic manually for both the present and absent case

---

_drafted by Claude on behalf of Daniel Stephenson_