### PR TITLE
Mention CI in CONTRIBUTING's validation step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,13 @@ contributors:
    capability, `fix/<short-name>` for corrections.
 2. Edit `create-dev-loop.md` (and `README.md` / `RESEARCH.md` / `CLAUDE.md`
    as needed — see "Project conventions" above).
-3. Validate your change. There is no automated test suite; the real test is
-   running `/create-dev-loop` against a real repository and confirming:
+3. Validate your change. CI (`.github/workflows/ci.yml`) runs automatically
+   on your PR and mechanically checks two of the rules above — every
+   `{{placeholder}}` has a substitution-table row, and README's Step list
+   stays 1:1 with `create-dev-loop.md` — plus local relative-link checks. It
+   catches doc drift, not behavior. There is no automated behavioral test
+   suite; the real test for behavior is running `/create-dev-loop` against a
+   real repository and confirming:
    - the generated skill file compiles (no unresolved `{{placeholders}}`
      remain)
    - the slash command link resolves correctly


### PR DESCRIPTION
## Summary
- CONTRIBUTING.md's "Making a change" step 3 said "There is no automated test suite" and jumped straight to the manual behavioral checklist, without mentioning that `.github/workflows/ci.yml` runs `scripts/check_docs.py` automatically on every PR. A new contributor reading only CONTRIBUTING.md would have no idea their PR gets an automated doc-consistency check.
- Now states what CI actually checks (placeholder/substitution-table sync, README Step-list 1:1, relative links) before noting it doesn't cover behavior.

## Research grounding
Docs-only change, no template/phase behavior touched — no RESEARCH.md finding applies.

## Test plan
- [x] `python3 scripts/check_docs.py` passes
- [x] No placeholders or Steps touched

---

_drafted by Claude on behalf of Daniel Stephenson_