### PR TITLE
Add MIT license badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # create-dev-loop
 
 [![CI](https://github.com/dmccoystephenson/create-dev-loop/actions/workflows/ci.yml/badge.svg)](https://github.com/dmccoystephenson/create-dev-loop/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
 
 A Claude Code skill that generates a **tailored autonomous dev loop** for any git repository — one slash command away from continuous, repo-aware development.
 


### PR DESCRIPTION
## Summary
- Adds a standard MIT license badge next to the existing CI badge — quick visual signal for anyone landing on the repo, now that it's OSS-prepped and MIT-licensed (#59).

## Research grounding
Docs-only, no template/phase behavior — no RESEARCH.md finding applies.

## Test plan
- [x] `python3 scripts/check_docs.py` passes
- [x] Badge links to LICENSE.md, which exists at repo root

---

_drafted by Claude on behalf of Daniel Stephenson_