### PR TITLE
Expand doc link check to .github/*.md

### DIFF
--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -96,7 +96,9 @@ def check_readme_steps_sync(cdl_text: str, readme_text: str) -> None:
 
 def check_local_links() -> None:
     link_re = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
-    for doc in REPO_ROOT.glob("*.md"):
+    for doc in REPO_ROOT.rglob("*.md"):
+        if ".git" in doc.parts:
+            continue
         text = doc.read_text(encoding="utf-8")
         for target in link_re.findall(text):
             if target.startswith(("http://", "https://", "mailto:")):
@@ -104,7 +106,7 @@ def check_local_links() -> None:
             path_part = target.split("#", 1)[0]
             if not path_part:
                 continue
-            resolved = (REPO_ROOT / path_part).resolve()
+            resolved = (doc.parent / path_part).resolve()
             if not resolved.exists():
                 errors.append(f"{doc.name}: broken relative link -> {target}")
 


### PR DESCRIPTION
## Summary
- `check_local_links()` only globbed `REPO_ROOT.glob("*.md")` -- top-level files only -- so `.github/PULL_REQUEST_TEMPLATE.md` and the three `.github/ISSUE_TEMPLATE/*.md` files were never checked for broken relative links. Currently none of them have links, so this was a silent coverage gap rather than an active bug, but a future edit adding one would pass CI unchecked.
- Switched to `REPO_ROOT.rglob("*.md")` (skipping `.git/`) to cover the whole repo.
- While there: fixed link resolution to be relative to the **linking file's own directory** (`doc.parent`) rather than always `REPO_ROOT`. This matches how GitHub actually renders relative markdown links and only matters once non-root-level docs are in scope -- for the existing top-level docs, `doc.parent == REPO_ROOT`, so behavior is unchanged there.
- Verified detection by temporarily appending a broken link to `PULL_REQUEST_TEMPLATE.md` locally, confirming the script now fails on it, then reverting.

## Research grounding
Tooling/CI-script change, not the template or a phase definition -- no RESEARCH.md finding applies.

## Test plan
- [x] `python3 scripts/check_docs.py` passes on the current tree
- [x] Manually confirmed it now catches a broken link planted in `.github/PULL_REQUEST_TEMPLATE.md` (reverted before commit)
- [x] No `{{placeholder}}` or Step changes

---

_drafted by Claude on behalf of Daniel Stephenson_