### PR TITLE
Add CONTRIBUTING.md, SECURITY.md, PR template to doc sources-of-truth table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,6 @@ The maintainer validates against private reference implementations (`dpm-dev-loo
 | `create-dev-loop.md` | Steps, template placeholders, and substitution table are internally consistent |
 | `README.md` | Described behavior matches what `create-dev-loop.md` actually does |
 | `RESEARCH.md` | Empirical findings are accurate, citations resolve, confidence levels reflect the current state of the evidence |
+| `CONTRIBUTING.md` | Restated conventions and the validation checklist still match this file (`CLAUDE.md`) |
+| `SECURITY.md` | The trust model still matches what Step 2 of `create-dev-loop.md` actually reads from the target repo |
+| `.github/PULL_REQUEST_TEMPLATE.md` | Doc-sync checkboxes and test-plan guidance match the current CI scope and this file (`CLAUDE.md`) |


### PR DESCRIPTION
## Summary
- `CLAUDE.md`'s "Documentation sources of truth" table only listed `create-dev-loop.md`, `README.md`, `RESEARCH.md` -- but the repo has since gained `CONTRIBUTING.md` (#63), `SECURITY.md` (#68), and `.github/PULL_REQUEST_TEMPLATE.md`/`ISSUE_TEMPLATE/*` (#64), all of which make verifiable claims.
- Neither the generated skill's Phase 7 (PR-scoped doc check) nor Phase 2 Stage A (repo-wide sweep) checks anything outside this table -- confirmed concretely: the PR template carried stale pre-CI framing through 7 merged PRs (#65-#71) before a manual Stage A sweep caught it by hand (PR #72).
- Added the 3 missing rows, matching the wording issue #74 proposed.

Closes #74

## Note on scope
This edits `CLAUDE.md`, which the generated skill's own Phase 1 flags as agent-loaded config requiring explicit, separate user authorization before an autonomous cycle may touch it (issue #74 was filed rather than fixed for exactly this reason). Opening this under the maintainer's direct, in-session request to polish the repo, which is that authorization.

## Research grounding
Project-bookkeeping change, not a claim about agent behavior -- no `RESEARCH.md` finding applies (matches issue #74's own assessment).

## Test plan
- [x] `python3 scripts/check_docs.py` passes
- [x] Verified the 3 newly-listed files against their own current content: `.github/PULL_REQUEST_TEMPLATE.md` already matches CI's actual scope (fixed by PR #72), `CONTRIBUTING.md` and `SECURITY.md` both still accurately restate `CLAUDE.md`'s conventions and Step 2's actual read behavior
- [x] No `{{placeholder}}` or Step changes

---

_drafted by Claude on behalf of Daniel Stephenson_