### PR TITLE
Fix Step 1 update-mode scratch file and stale example-skills-catalog reference

### DIFF
--- a/create-dev-loop.md
+++ b/create-dev-loop.md
@@ -27,7 +27,7 @@ ls ~/.claude/commands/<slug>-dev-loop.md 2>/dev/null
 
 **If a skill already exists**, ask the user to choose:
 
-- **update** *(default)* — re-derive the skill from the current template and current repo state, producing a fresh skill file. Set `MODE=update`. Steps 2–5 run; Steps 6 (create GitHub repo) and 7 (record in `my-claude-skills`) are skipped because those artifacts already exist.
+- **update** *(default)* — re-derive the skill from the current template and current repo state, producing a fresh skill file. Set `MODE=update`. Steps 2–5 run; Steps 6 (create GitHub repo) and 7 (record in the personal catalog) are skipped because those artifacts already exist.
 - **overwrite** — re-derive and replace as in fresh generation. Set `MODE=overwrite`. Steps 6–7 still run, idempotently re-asserting the repo and registry entry.
 - **cancel** — exit without changes.
 
@@ -37,11 +37,13 @@ cd ~/local-skills/<slug>-dev-loop && git status --porcelain
 ```
 If the output is non-empty, stop and ask the user to commit or stash their edits — the update would otherwise overwrite in-progress work.
 
-In **update mode**, after Step 4 completes, show the user a diff between the existing skill file and the freshly generated content *before* overwriting:
+In **update mode**, after Step 4 completes, write the freshly generated content to a scratch file using the `Write` tool — not `>` shell redirection, which some harness sandboxes statically block even for files the same session just created (the same constraint the generated template's Phase 3 teaches its own children) — at `~/local-skills/<slug>-dev-loop/<slug>-dev-loop.md.new`. Use that path, inside the directory the generator already owns, rather than `/tmp`: out-of-repo scratch writes can be blocked even when in-repo `Write` calls succeed. **If the scratch write fails, abort the update and report the failure** — do not fall back to overwriting without having shown the diff; the diff is the only confirmation gate protecting the user's existing skill file.
+
+Show the user a diff between the existing skill file and the scratch file *before* overwriting:
 ```bash
-diff -u ~/local-skills/<slug>-dev-loop/<slug>-dev-loop.md /tmp/<slug>-dev-loop.new.md
+diff -u ~/local-skills/<slug>-dev-loop/<slug>-dev-loop.md ~/local-skills/<slug>-dev-loop/<slug>-dev-loop.md.new
 ```
-Get explicit confirmation before replacing the file.
+Get explicit confirmation before replacing the file. After the file is replaced (or the update is declined), remove the scratch file: `python3 -c "import os; os.remove(path)"` (not `rm`, for the same sandbox reason).
 
 ---
 


### PR DESCRIPTION
## Summary
- Step 1's update-mode diff referenced `/tmp/<slug>-dev-loop.new.md` without ever saying how that file is produced. The natural reading was shell `>` redirection into `/tmp` -- exactly the pattern PR #67 documented as blocked in some harness sandboxes, and `/tmp` is outside the repo directory some sandboxes restrict even when in-repo writes succeed. If the scratch write silently failed, the pre-overwrite diff -- the only confirmation gate protecting an existing skill file -- could be skipped.
- Now: names the `Write` tool as the mechanism, uses an in-repo scratch path (`~/local-skills/<slug>-dev-loop/<slug>-dev-loop.md.new`), and fails closed -- abort and report rather than overwrite without having shown the diff -- if the scratch write fails. Cleans up with `python3 -c "import os; os.remove(path)"` rather than `rm`, matching PR #67's rationale.
- Fixed a second, smaller drift found while in this section: the MODE=update bullet still said "record in `example-skills-catalog`" after PR #69 renamed Step 7 to an optional personal catalog and made it conditional on the directory existing.

Closes #73

## Note on scope
`create-dev-loop.md` is on the do-not-auto-merge list -- issue #73 explicitly flagged that this needs human review before merge and validation via a `MODE=update` end-to-end run per `CLAUDE.md`'s "Testing changes" item 5. Opening under the maintainer's direct, in-session request to polish the repo.

## Research grounding
No `RESEARCH.md` finding applies -- this is the same class of harness/sandbox operational observation PR #67 explicitly declined to force a citation for (matches issue #73's own assessment).

## Test plan
- [x] `python3 scripts/check_docs.py` passes
- [x] No `{{placeholder}}` added or changed; no Step count/numbering change
- [ ] **UNVERIFIED** -- a full `MODE=update` end-to-end dry run against a fixture repo with an existing generated skill was not performed. This session has no fixture repo with a pre-existing `<slug>-dev-loop` skill to update against, and the sandbox restricts filesystem writes outside this repo's own working directory (the same constraint this PR documents). The change is prose-only inside an existing Step (no placeholders, no fence/escaping changes, no Step renumbering), which lowers risk, but a maintainer with a real fixture should confirm `MODE=update` still produces a reviewable diff and correctly cleans up the scratch file before treating this as fully verified.

---

_drafted by Claude on behalf of Daniel Stephenson_