### PR TITLE
Fix doc drift in the trust model and restated conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,16 @@ contributors:
 - If your change implements or contradicts a finding in `RESEARCH.md`,
   update that file in the same PR (see its "How to use this document"
   section for the entry format).
+- Repo-specific findings (build commands, reviewer names, branch prefixes)
+  belong **only** in a generated skill — never back-port them into
+  `create-dev-loop.md`. Only changes to *how repos are explored or how
+  skills are structured* belong here.
+- Steps 3, 5, and 6 are a load-bearing interface, not internal detail:
+  downstream tooling reads generated skills from exactly the paths Steps 3
+  and 5 write, and depends on the repo Step 6 creates. Changing where a
+  skill is written, what it's named, or what Step 6 creates is a breaking
+  change — call it out in your PR description. See "What belongs here vs.
+  in gardener" in [`CLAUDE.md`](CLAUDE.md).
 
 ## Making a change
 
@@ -59,8 +69,10 @@ contributors:
    one the first time — Step 6 creates a GitHub repo, and Steps 3 and 5
    write to `~/local-skills/` and `~/.claude/commands/`.
 4. Commit using imperative mood, no trailing period (e.g. `Add SKILL_REPO_OWNER placeholder`).
+   Don't add a co-author trailer unless an AI agent actually authored the commit.
 5. Open a PR referencing any related issue with `Closes #N`. Describe what
-   you tested it against.
+   you tested it against. PRs are squash-merged and the branch is deleted
+   after merge.
 
 ## Retrofitting existing generated skills
 

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -16,7 +16,7 @@ This document records the empirical findings that inform the design of `create-d
 - **First-party sources** (Anthropic, OpenAI, vendor research with numbers) count as evidence but must be flagged as first-party so readers can weight them appropriately.
 - **Confidence levels**: `high` = replicated across multiple independent studies; `medium` = one well-cited study, plausible; `low` = single paper, contested, or inferred from adjacent literature.
 
-Last reviewed: 2026-07-27.
+Last reviewed: 2026-07-29.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,10 @@ identity, its reviewer, or its branch prefix. Step 4 also derives from it:
   executes them verbatim — in its Phase 3 build-verification step and its
   Phase 4 external-signal anchor.
 - **Which paths are exempt from autonomous merge.** `DO_NOT_AUTO_MERGE`
-  decides what the generated skill refuses to merge without a human.
+  adds to the paths the generated skill refuses to merge without a human.
+  It can only widen that list — a universal baseline (`.github/workflows/*`,
+  anything under `security/`, large deletions) holds regardless of what the
+  target repo says.
 - **What the skill checks itself against.** `SELF_REVIEW_RUBRIC` becomes
   the repo-specific half of its pre-merge self-review.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,15 +18,30 @@ You should expect an initial response within a few days.
 ## Trust model
 
 `/create-dev-loop` reads files from whatever repository you run it in —
-`CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, CI configs, `CODEOWNERS`, and
-recent PR descriptions — and uses their content to decide what the
-generated skill does: its stated identity, its self-review rubric, its
-reviewer, its branch conventions, and so on (Step 2 of
+`CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, build files (`pom.xml`,
+`package.json`, `Cargo.toml`, `Makefile`, `pyproject.toml`, `go.mod`, …),
+CI workflows, linter and formatter configs, `CODEOWNERS`, the PR template,
+documentation sources, and recent commit and PR history — and uses their
+content to decide what the generated skill does (Step 2 of
 `create-dev-loop.md`).
 
-This means the target repo's content directly shapes an autonomous
-skill that will later create branches, open PRs, and push commits with
-`gh`/`git`. **Only run `/create-dev-loop` against repositories you trust.**
+That content shapes more than cosmetic details like the skill's stated
+identity, its reviewer, or its branch prefix. Step 4 also derives from it:
+
+- **The shell commands the generated skill runs.** `COMPILE_CMD`,
+  `TEST_CMD`, `LINT_CMD`, and `EXTERNAL_SIGNAL_CMD` are taken from the
+  target repo's build files and CI workflows, and the generated skill
+  executes them verbatim — in its Phase 3 build-verification step and its
+  Phase 4 external-signal anchor.
+- **Which paths are exempt from autonomous merge.** `DO_NOT_AUTO_MERGE`
+  decides what the generated skill refuses to merge without a human.
+- **What the skill checks itself against.** `SELF_REVIEW_RUBRIC` becomes
+  the repo-specific half of its pre-merge self-review.
+
+This means the target repo's content directly shapes an autonomous skill
+that will later run those commands and create branches, open PRs, push
+commits, and merge PRs with `gh`/`git`. **Only run `/create-dev-loop`
+against repositories you trust.**
 A repository crafted to manipulate the generation process (e.g. planted
 instructions in `CLAUDE.md` aimed at the agent rather than at humans) could
 cause the generated skill to encode unsafe or unintended behavior. This is


### PR DESCRIPTION
## Summary

A Stage A documentation-accuracy sweep — a full pass over every file in `CLAUDE.md`'s "Documentation sources
of truth" table, verifying each claim against `create-dev-loop.md` and `scripts/check_docs.py` rather than
against memory. Three files had drifted; the fixes are doc-only.

**`SECURITY.md` — the trust model understated what the target repo controls.** `CLAUDE.md` requires this file
to match "what Step 2 of `create-dev-loop.md` actually reads from the target repo." It didn't:

- Its list of reads omitted build files, linter/formatter configs, the PR template, documentation sources,
  and commit history — Step 2 reads all of them.
- More importantly, it framed the consequence as cosmetic ("its stated identity, its reviewer, its branch
  conventions"). The sharper consequence was missing entirely: Step 4 derives `COMPILE_CMD`, `TEST_CMD`,
  `LINT_CMD`, and `EXTERNAL_SIGNAL_CMD` from the target repo's build files and CI workflows, and the
  generated skill **executes them verbatim**. `DO_NOT_AUTO_MERGE` — which the target repo also supplies —
  decides what that skill will refuse to merge without a human.
- Its list of what the skill later does ("create branches, open PRs, and push commits") omitted running those
  derived commands and merging PRs (Phase 8 `gh pr merge --squash`).

For a document whose whole job is telling readers why to only run this against repos they trust, "the repo
you point this at chooses the shell commands the agent will run and which paths it may auto-merge" is the
load-bearing sentence, and it wasn't there.

**`CONTRIBUTING.md` — restated conventions were incomplete.** `CLAUDE.md` requires this file's restated
conventions to match it. Three were absent: repo-specific findings belong only in a generated skill and must
never be back-ported; Steps 3/5/6 are a load-bearing downstream interface whose changes need flagging in the
PR description; and the squash-merge/delete-branch and co-author-trailer conventions. The Steps 3/5/6 rule is
referenced through `CLAUDE.md`'s own section rather than by adding a second hyperlink to the gardener repo —
see #79 for why.

**`RESEARCH.md`** — "Last reviewed" bumped to 2026-07-29 to reflect this sweep. All eight findings, their
citations, confidence levels, and **Implementations** entries were re-read; no inaccuracy found.

## Filed rather than fixed here

Three findings from the sweep are code, not doc drift, so per the Stage A rule ("if the *code* is what's
wrong, file an issue and leave it for an implementation cycle") they are issues:

- #79 — `README.md` and `CLAUDE.md` link `dmccoystephenson/gardener` and call it open source; `gh repo view`
  reports it **private**, so the link 404s for every reader. Resolving it needs a maintainer decision
  (publish the repo vs. soften the docs), and one of the two files is agent-loaded config.
- #80 — `check_docs.py` parses the Step 4 substitution table through a fixed 8000-byte window with 231 bytes
  of headroom; once the table outgrows it, CI reports existing rows as missing.
- #81 — `CLAUDE.md`'s doc-sources table omits `.github/ISSUE_TEMPLATE/*.md`, which restate conventions the
  same way the PR template does.

No open issues existed at triage, so nothing was deferred.

## Research grounding

No finding applies. This is a documentation-accuracy correction; it touches no template placeholder, no Step
logic, and no phase definition. `RESEARCH.md`'s only change is the review date — no finding, citation,
confidence level, or **Implementations** entry is added, removed, or reinterpreted.

## Doc sync check

- [x] `README.md`'s "What it does" Step list still matches `create-dev-loop.md`'s Steps 1:1 — unchanged, and verified by `scripts/check_docs.py`
- [x] Every `{{placeholder}}` added or changed has a corresponding Step 4 substitution-table row — none added or changed
- [x] `RESEARCH.md` updated — review date only, per above

## Test plan

- [x] `python3 scripts/check_docs.py` passes locally (placeholder/table coverage, README ↔ Steps 1:1, relative links). CI runs it on this PR.
- [x] Every new `SECURITY.md` claim traced to source: the read list against Step 2's file enumeration; `COMPILE_CMD`/`TEST_CMD`/`LINT_CMD`/`EXTERNAL_SIGNAL_CMD`/`DO_NOT_AUTO_MERGE`/`SELF_REVIEW_RUBRIC` against their Step 4 rows; "Phase 3 build-verification step" and "Phase 4 external-signal anchor" against where those placeholders actually appear in the embedded template; "merge PRs" against Phase 8's `gh pr merge --squash`.
- [x] Every new `CONTRIBUTING.md` line traced to the `CLAUDE.md` section it restates.
- [x] New relative link `[CLAUDE.md](CLAUDE.md)` resolves — covered by `check_local_links`.

**Behavioral anchor: UNVERIFIED-not-applicable.** `create-dev-loop.md` is untouched, as are the Step 4
substitution table and all Step 1/5–7 logic, so there is no generation behavior for a `/create-dev-loop` run
against a live repo to verify. Per the dev-loop's Phase 4 scope gate, that is the documented condition for
recording the anchor as not-applicable rather than required.

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._