### PR TITLE
Bound Step 4 substitution-table scan by heading, not a fixed byte window

### DIFF
--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -60,7 +60,8 @@ def check_placeholders(text: str, template_body: str) -> None:
     if table_start == -1:
         errors.append("Could not find the '### 4 — Fill in the placeholders' section.")
         return
-    table_section = text[table_start:table_start + 8000]
+    next_heading = text.find("\n### ", table_start + 1)
+    table_section = text[table_start:next_heading if next_heading != -1 else len(text)]
 
     declared = set()
     for line in table_section.splitlines():


### PR DESCRIPTION
## Summary
- `check_docs.py` read the Step 4 substitution table through a hardcoded `table_start + 8000` byte window, which had shrunk to ~231 bytes of headroom against the current template.
- A table row falling outside that window silently drops out of `declared`, so `check_placeholders` reports a placeholder as "missing a Step 4 substitution-table row" even when the row exists — a misleading CI failure pointing contributors at the wrong problem.
- Bound the scan by the next `### ` heading instead of a byte count, so the section boundary tracks the template's actual structure as the table grows.

## Research grounding
No `RESEARCH.md` finding applies — this is a mechanical CI-tooling correctness fix (byte-window vs. structural parsing), not a change to `create-dev-loop.md`'s template or phase definitions.

## Test plan
- [x] `python3 scripts/check_docs.py` passes cleanly on the current tree with the fix applied.
- [x] Regression check (per the issue's suggestion): simulated a placeholder used in the template body with its substitution-table row pushed past byte 8000 (via padding rows). Confirmed the **old** windowed logic drops the row from `declared` (false "missing" report), and the **new** heading-bounded logic correctly finds it.
- [x] No `.claude/` state staged (`git status --porcelain` before commit showed only `scripts/check_docs.py`).
- Not applicable: this PR doesn't touch `create-dev-loop.md`/the template surface, so the `/create-dev-loop`-against-a-fixture validation in `CLAUDE.md`'s "Testing changes" section doesn't apply here.

Closes #80

---

_drafted by Claude on behalf of Daniel Stephenson_