### PR TITLE
Fold in round-2 public-readiness nice-to-haves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,4 +72,4 @@ Validate by running `/create-dev-loop` against any real repository you maintain 
 | `CONTRIBUTING.md` | Restated conventions and the validation checklist still match this file (`CLAUDE.md`) |
 | `SECURITY.md` | The trust model still matches what Step 2 of `create-dev-loop.md` actually reads from the target repo |
 | `.github/PULL_REQUEST_TEMPLATE.md` | Doc-sync checkboxes and test-plan guidance match the current CI scope and this file (`CLAUDE.md`) |
-| `.github/ISSUE_TEMPLATE/*.md` | Restated conventions and Step names still match this file (`CLAUDE.md`) |
+| `.github/ISSUE_TEMPLATE/*.md` | Restated conventions and Step names still match this file (`CLAUDE.md`) — `config.yml` in the same directory has no restatable conventions and is outside this glob |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Register `create-dev-loop.md` itself as a slash command by symlinking it into `~
 
 ```
 mkdir -p ~/.claude/commands
-ln -s "$(pwd)/create-dev-loop.md" ~/.claude/commands/create-dev-loop.md
+ln -sf "$(pwd)/create-dev-loop.md" ~/.claude/commands/create-dev-loop.md
 ```
 
 This is a one-time setup step for this repo's own product, distinct from Step 5, which registers each *generated* skill the same way.

--- a/tests/test_check_docs.py
+++ b/tests/test_check_docs.py
@@ -2,7 +2,9 @@
 
 Each of check_docs.py's three checks appends to a module-level `errors`
 list rather than returning a value, so these tests reset that list before
-each call and assert on its contents afterward.
+each call and assert on its contents afterward. Any new test class added
+here must do the same in its own setUp() — skipping the reset lets a
+prior test's errors leak into the next assertion.
 """
 import sys
 import unittest


### PR DESCRIPTION
## Summary

Addresses the remaining actionable nice-to-haves from the round-2 public-readiness re-review (post-merge of #102), plus cleans up the last 4 stale, already-merged branches.

- `README.md`: Installation symlink now uses `ln -sf`, matching Step 5's own registration convention (`create-dev-loop.md:624`) instead of the plain `ln -s` it shipped with in #102.
- `CLAUDE.md`: clarifies the ISSUE_TEMPLATE doc-table row — the `*.md` glob deliberately excludes `config.yml`, which has no restatable conventions.
- `tests/test_check_docs.py`: module docstring now notes that any new test class must reset `check_docs.errors` in its own `setUp()`, so a future addition doesn't silently leak state between tests.
- Deleted the last 4 stale, already-squash-merged branches (`feature/add-research-md`, `feature/localization-and-command-sub-fixes`, `feature/rubric-based-self-review`, `license-mit`) — all confirmed `MERGED` via `gh pr list --state all --head <branch>` before deletion. (7 of the original 11 flagged in round 1 had already been cleaned up by the time of this review.)

**Not included, with reasons** (both re-verified independently rather than assumed from the review):
- RESEARCH.md's "Observed effect: pending — needs N cycles of data" entries (PRs #29/#30/#52/#54) — this needs real usage data only the maintainer can supply; there's nothing to mechanically edit without fabricating an observed effect.
- The flagged `openai.com` RESEARCH.md link — re-fetched independently, still returns 403 (not 404), consistent with bot/WAF blocking a non-browser client rather than a genuinely dead link. Left as-is; worth a manual browser check if you want to be certain.

**Note:** this repo's canonical location is now `Stephenson-Software/create-dev-loop` (transferred since round 1's review, which still referenced `dmccoystephenson/create-dev-loop`) — this PR and the branch deletions above target the canonical org.

## Test plan

- `python3 scripts/check_docs.py` passes.
- `python3 -m unittest discover -s tests -v` — 13/13 pass.
- Verified all 4 deleted branches were `MERGED` via `gh pr list --state all --head <branch>` before deleting.
- Independently re-fetched the flagged RESEARCH.md link to confirm 403 vs. 404 before deciding not to touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_