### PR TITLE
Correct stale CI scope, command surface, and repo owner in the docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,8 +24,10 @@ touch the template (e.g. docs-only).
 <!--
 CI (.github/workflows/ci.yml) runs scripts/check_docs.py on every PR and
 mechanically checks the first two Doc sync boxes above, plus relative links
-between the repo's own docs. It catches doc drift, not behavior. There is no
-automated behavioral test suite, so describe how you validated the change —
+between the repo's own docs. It then runs tests/test_check_docs.py, the unit
+tests for that script — add cases there if you changed its logic. CI catches
+doc drift, not the template's behavior. There is no automated behavioral test
+suite, so describe how you validated the change —
 see CLAUDE.md's "Testing changes" section (running /create-dev-loop against
 a real repo and checking the generated skill compiles, MODE=update behaves
 correctly, etc.).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,8 +27,7 @@ mechanically checks the first two Doc sync boxes above, plus relative links
 between the repo's own docs. It then runs tests/test_check_docs.py, the unit
 tests for that script — add cases there if you changed its logic. CI catches
 doc drift, not the template's behavior. There is no automated behavioral test
-suite, so describe how you validated the change —
-see CLAUDE.md's "Testing changes" section (running /create-dev-loop against
-a real repo and checking the generated skill compiles, MODE=update behaves
-correctly, etc.).
+suite, so describe how you validated the change — see CLAUDE.md's "Testing
+changes" section (running /create-dev-loop against a real repo and checking
+the generated skill compiles, MODE=update behaves correctly, etc.).
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,12 @@ contributors:
    on your PR and mechanically checks two of the rules above — every
    `{{placeholder}}` has a substitution-table row, and README's Step list
    stays 1:1 with `create-dev-loop.md` — plus local relative-link checks. It
-   catches doc drift, not behavior. There is no automated behavioral test
-   suite; the real test for behavior is running `/create-dev-loop` against a
-   real repository and confirming:
+   also runs `tests/test_check_docs.py`, fixture-based unit tests of
+   `scripts/check_docs.py` itself, so a silently-broken check can't read as
+   "0 errors → pass"; add cases there when you change that script's logic.
+   CI catches doc drift, not the template's behavior. There is no automated
+   behavioral test suite; the real test for behavior is running
+   `/create-dev-loop` against a real repository and confirming:
    - the generated skill file compiles (no unresolved `{{placeholders}}`
      remain)
    - the slash command link resolves correctly

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # create-dev-loop
 
-[![CI](https://github.com/dmccoystephenson/create-dev-loop/actions/workflows/ci.yml/badge.svg)](https://github.com/dmccoystephenson/create-dev-loop/actions/workflows/ci.yml)
+[![CI](https://github.com/Stephenson-Software/create-dev-loop/actions/workflows/ci.yml/badge.svg)](https://github.com/Stephenson-Software/create-dev-loop/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
 
 A Claude Code skill that generates a **tailored autonomous dev loop** for any git repository — one slash command away from continuous, repo-aware development.
@@ -84,7 +84,7 @@ Each generated `<slug>-dev-loop` skill encodes:
 A generated skill is invoked interactively, one repo at a time, as
 `/<slug>-dev-loop`. To run them unattended across a whole fleet of repos —
 on a schedule, with safety gating and a merge allow-list — see
-[`gardener`](https://github.com/dmccoystephenson/gardener), this project's
+[`gardener`](https://github.com/Stephenson-Software/gardener), this project's
 open-source companion. `gardener tend` dispatches a repo's generated skill
 headlessly and bootstraps one via `/create-dev-loop` if the repo doesn't
 have one yet; `gardener overnight` does that across an opt-in list of repos

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -16,7 +16,7 @@ This document records the empirical findings that inform the design of `create-d
 - **First-party sources** (Anthropic, OpenAI, vendor research with numbers) count as evidence but must be flagged as first-party so readers can weight them appropriately.
 - **Confidence levels**: `high` = replicated across multiple independent studies; `medium` = one well-cited study, plausible; `low` = single paper, contested, or inferred from adjacent literature.
 
-Last reviewed: 2026-07-29.
+Last reviewed: 2026-08-04.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,8 +31,10 @@ identity, its reviewer, or its branch prefix. Step 4 also derives from it:
 - **The shell commands the generated skill runs.** `COMPILE_CMD`,
   `TEST_CMD`, `LINT_CMD`, and `EXTERNAL_SIGNAL_CMD` are taken from the
   target repo's build files and CI workflows, and the generated skill
-  executes them verbatim — in its Phase 3 build-verification step and its
-  Phase 4 external-signal anchor.
+  executes them verbatim — in its Phase 3 build-verification step, its
+  Phase 4 external-signal anchor, and its Phase 8 post-rebase re-check.
+  `REVALIDATE_INSTRUCTION`, derived from the same sources, points Phase 6
+  at that same check after every review fix.
 - **Which paths are exempt from autonomous merge.** `DO_NOT_AUTO_MERGE`
   adds to the paths the generated skill refuses to merge without a human.
   It can only widen that list — a universal baseline (`.github/workflows/*`,


### PR DESCRIPTION
## Summary

A Stage A documentation-accuracy sweep was run across every documentation source of
truth listed in `CLAUDE.md`. Four stale claims were found and corrected; two defects
that live in `create-dev-loop.md`'s behavior or in agent-loaded configuration were
filed rather than changed here.

**CI scope was understated in two places.** `.github/workflows/ci.yml` runs two steps —
`scripts/check_docs.py` and `python3 -m unittest discover -s tests`. Both
`CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` described only the first,
so a contributor changing `scripts/check_docs.py` was never told that
`tests/test_check_docs.py` exists and needs new cases. `CLAUDE.md` already documents
the unit tests, and its documentation-sources table requires the PR template's
test-plan guidance to "match the current CI scope" and `CONTRIBUTING.md`'s validation
checklist to match `CLAUDE.md` — both rows were out of date. The phrase "catches doc
drift, not behavior" was also sharpened to "not the template's behavior", since the
suite does test `check_docs.py`'s own behavior.

**`SECURITY.md` named only two of the four places a target-repo-derived command is
executed.** The trust model stated that `COMPILE_CMD` / `TEST_CMD` / `LINT_CMD` /
`EXTERNAL_SIGNAL_CMD` run "in its Phase 3 build-verification step and its Phase 4
external-signal anchor". `{{TEST_CMD}}` is also substituted into the Phase 8
post-rebase fence of the generated template, and `{{REVALIDATE_INSTRUCTION}}` — derived
from the same target-repo sources — points Phase 6 at that same check after every
review fix. Under-counting the execution surface understates the blast radius the
document exists to describe.

**Both repositories referenced by `README.md` have moved to the `Stephenson-Software`
organization.** `gh repo view` resolves this repository as
`Stephenson-Software/create-dev-loop` and `dmccoystephenson/gardener` as
`Stephenson-Software/gardener`. The CI badge and the `gardener` link were updated to
the canonical owner. They resolved before only via GitHub's owner redirect, which would
silently point at the wrong project if a repository were ever created at the old path.
The two remaining `dmccoystephenson` links, in `SECURITY.md` and `CODE_OF_CONDUCT.md`,
point at the maintainer's personal profile and are correct as written; they were left
alone.

**`RESEARCH.md`'s "Last reviewed" date was bumped to 2026-08-04**, matching the
precedent set by the sweep in PR #82. All eight findings, their confidence levels, and
their **Implementations** entries were re-checked and are accurate. Every one of the
17 arXiv citations plus the METR, Chroma, and Anthropic links was fetched and returned
`200`. The `openai.com` citation returns `403` — a WAF block against a non-browser
client, not a dead link, consistent with what PR #102 independently found. The PRs
merged since the last review (#89, #93, #95, #102, #103) each state in their own
descriptions that no finding applies, so no **Implementations** entry is missing.

## Filed rather than fixed

Per the Stage A rule that a defect in behavior is filed and left for an implementation
cycle rather than changed silently under a docs-only PR:

- #105 — Step 2 of `create-dev-loop.md` names only `.github/pull_request_template.md`.
  The uppercase spelling used by this very repository would be skipped silently on a
  case-sensitive filesystem, despite `SECURITY.md` documenting the PR template as
  something Step 2 reads.
- #106 — `CLAUDE.md` line 26 still links `gardener` under the old owner. It was left
  untouched because agent-loaded configuration requires separate, explicit
  authorization to edit.

## Deferred backlog

Issue #87 was the only open issue at triage time and was not selected. A prior cycle
deliberately left it open, and its comment records why: the fix is an edit to a
generated skill file, which this loop is not authorized to make autonomously. The
underlying gap is tracked at its proper home as `cdl-dev-loop#14`.

## Research grounding

No `RESEARCH.md` finding applies. This PR changes no phase definition, no placeholder,
no Step, and no template logic — it corrects factual claims in the supporting docs
about CI scope, command-execution surface, and repository ownership. Per `CLAUDE.md`'s
research-grounding rule, that is stated explicitly rather than a citation being
stretched to fit.

## Doc sync check

- [x] `README.md`'s "What it does" Step list still matches `create-dev-loop.md`'s Steps 1:1 — no Step was added, removed, or renumbered; verified mechanically by `scripts/check_docs.py`
- [x] Every `{{placeholder}}` added or changed has a corresponding Step 4 substitution-table row — no placeholder was touched; verified mechanically
- [x] `RESEARCH.md` updated — review date only, per above

## Test plan

- [x] `python3 scripts/check_docs.py` → `Doc consistency check passed.`
- [x] `python3 -m unittest discover -s tests` → `Ran 13 tests` / `OK`
- [x] Every external link in every root `*.md` fetched; all `200` except the two known WAF `403`s (`claude.ai/code`, `openai.com`) and one `$OWNER` placeholder inside a Step 7 code example
- [x] Each corrected claim re-read against its source: `.github/workflows/ci.yml` for the CI scope, the Phase 3 / 4 / 6 / 8 substitution sites in `create-dev-loop.md` for the command surface, `gh repo view` for both repository owners
- [ ] Manual validation (`/create-dev-loop` against a real repo) — **UNVERIFIED-not-applicable.** The generated-skill anchor is required only when the PR changes the embedded template, the Step 4 substitution table, or Step 1/5–7 logic. This PR touches none of them: no file under `create-dev-loop.md` is modified at all. CI is the operative anchor here and covers every changed file.

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).
